### PR TITLE
fix: fixes search relevance to provide better search results

### DIFF
--- a/packages/gatsby-theme-aio/algolia/records/record-utils.js
+++ b/packages/gatsby-theme-aio/algolia/records/record-utils.js
@@ -51,7 +51,7 @@ const createAlgoliaRecords = (node, records) => {
       anchor: record.html ? getAnchorLink(record.headings) : getAnchorLink(getHeadings(node, record)),
       url: getUrl(slug, node, record),
       absoluteUrl: getAbsoluteUrl(slug, node, record),
-      customRanking: record.customRanking ?? '',
+      customRanking: record.customRanking ?? getCustomRanking(node, record),
       // TODO: model should not have dependencies on env vars (should be wrapped in config object)
       [process.env.REPO_NAME]: contentDigest
     };
@@ -89,7 +89,7 @@ function getAnchorLink(linkHeadings) {
   return `#${linkHeadings
     .slice(-1)
     .toString()
-    ?.match(/[a-zA-Z]\w+/g)
+    ?.match(/[a-zA-Z0-9]\w+/g)
     ?.map((s) => s.toLowerCase())
     .join('-')}`;
 }
@@ -101,6 +101,11 @@ function getUrl(slug, node, record) {
 
 function getAbsoluteUrl(slug, node, record) {
   return `${process.env.AIO_FASTLY_PROD_URL}${getUrl(slug, node, record)}`;
+}
+
+function getCustomRanking(node, record) {
+  console.log(node);
+  return record.customRanking;
 }
 
 const removeDuplicateRecords = (records) => {

--- a/packages/gatsby-theme-aio/gatsby-config.js
+++ b/packages/gatsby-theme-aio/gatsby-config.js
@@ -118,9 +118,9 @@ module.exports = {
         dryRun: ALGOLIA_INDEXING_MODES[algoliaIndexingMode][1], // default: false
         continueOnFailure: false, // default: false, don't fail the build if algolia indexing fails
         settings: {
-          searchableAttributes: ['title', 'contentHeading', 'description,content'],
+          searchableAttributes: ['contentHeading', 'title', 'description,content'],
           attributesForFaceting: ['searchable(keywords)'],
-          attributesToSnippet: ['content:55', 'description:55'],
+          attributesToSnippet: ['content:40', 'description:40'],
           distinct: true,
           attributeForDistinct: 'url',
           snippetEllipsisText: '…',


### PR DESCRIPTION
## Description

_DRAFT STATUS: The draft status is set to wait on a third change I want to add that will further enhance the relevance of the search results: Adding a customRanking value for mdxAst results. The htmlExtractor results already have a customRanking based on the Heading level for the result. I'll do the same for mdxAst results._ 

PR fixes the relevancy by prioritizing `contentHeading` over `title`. This works better and is more appropriate to the way we are accessing the most relevant content — not by page, but by specific `contentHeading` which needs to be renamed to something like `closestRelevantHeading`, which is the heading level that precedes the content that is also deemed most relevant on the page.

Results of these changes refines the Algolia search parameters and rankings so that weird results like what Barkin showed in the search channel on Slack don't happen. 

Additional changes include reducing the number of words to show in the search result from the content or description from 55 to 40. Snippets of 55 words are a bit too excessive. 40 words (or less) should strike a balance between providing enough context and conserving space so that scrolling is not too excessive.

Headings with numbers in them are now resolved as correct anchor links as well.

## Motivation and Context

Search can always be better and we need to be diligent and continuous in our efforts to improve it.

## Before this fix

Notice the first three results. They are all linking to the same page, but at different anchors on that page. In addition, they are not even the correct anchors to link to.  

![image](https://user-images.githubusercontent.com/1828494/129757204-0f7d039b-b735-4d24-a540-fa3524fbd470.png)

## After this fix

Now the first three results are from the top results from different pages — which is the way it is supposed to work. The Algolia algorithm should be returning a **single result** per page, presenting the best record for that page to the user, out of the many records created for that page during the indexing process.

![image](https://user-images.githubusercontent.com/1828494/129758639-40f3a6a6-347d-4e14-8978-349ab74ba37f.png)
