### PR TITLE
fix(code): only remove last token when the last token is blank. fixes #505

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Code/index.js
+++ b/packages/gatsby-theme-aio/src/components/Code/index.js
@@ -42,7 +42,8 @@ const Code = ({ children, className = '', theme }) => {
   return (
     <Highlight {...defaultProps} code={children} language={language}>
       {({ className, tokens, getLineProps, getTokenProps }) => {
-        const lines = tokens.slice(0, -1);
+        const isEmptyItem = (token) => token && (token.length === 1 && token[0].empty);
+        const lines = isEmptyItem(tokens[tokens.length - 1]) ? tokens.slice(0, -1) : tokens;
         const isMultiLine = lines.length > 1;
         const textarea = createRef();
 
@@ -97,7 +98,7 @@ const Code = ({ children, className = '', theme }) => {
               </span>
             </div>
             <pre className={classNames(className, 'spectrum-Code spectrum-Code--sizeM')}>
-              {tokens.slice(0, -1).map((line, i) => {
+              {lines.map((line, i) => {
                 const { style: lineStyles, ...lineProps } = getLineProps({ line, key: i });
 
                 return (


### PR DESCRIPTION
## Description

When getting the list of tokens from prism, the Code component currently does this:

```
const lines = tokens.slice(0, -1);
```

(it actually does this twice, but I'll get to that)

This assumes that the last item in the `tokens` array is empty and _should_ be removed. This change first checks that the last item is empty and only removes it _if_ it is empty.

In the current implementation, the slice is actually done two times:
* Once to determine if there's multiple lines.
* Once when iterating through the tokens to output them for display.

In order to avoid duplication, I removed the second slice and just used the (potentially) modified `lines` array that is used to determine if multiple lines are present.

## Related Issue

#505 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Manual testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
