### PR TITLE
Cleaning up logic to include analytics bootstrap script

### DIFF
--- a/packages/gatsby-theme-aio/src/components/SEO/index.js
+++ b/packages/gatsby-theme-aio/src/components/SEO/index.js
@@ -23,22 +23,20 @@ const SEO = ({ title, description, keywords }) => (
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
     <link rel="icon" href="https://www.adobe.com/favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="https://www.adobe.com/favicon.ico" type="image/x-icon" />
-    {process.env.GATSBY_ADOBE_ANALYTICS_REPORT_SUITE && process.env.GATSBY_ADOBE_ANALYTICS_ENV && (
+    {process.env.GATSBY_ADOBE_ANALYTICS_ENV && (
       <script type="text/javascript">{`
         window.marketingtech = {
           'adobe': {
             'launch': {
               'property': 'global',
-              'environment': '${process.env.GATSBY_ADOBE_ANALYTICS_ENV}'
+              'environment': '${process.env.GATSBY_ADOBE_ANALYTICS_ENV || 'dev'}'
             },
             'analytics': {
-              'additionalAccounts': '${process.env.GATSBY_ADOBE_ANALYTICS_REPORT_SUITE}' 
+              'additionalAccounts': '${process.env.GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS || ''}'
             }
           }
         };
       `}</script>
-    )}
-    {process.env.GATSBY_ADOBE_ANALYTICS_REPORT_SUITE && process.env.GATSBY_ADOBE_ANALYTICS_ENV && (
       <script src="https://www.adobe.com/marketingtech/main.min.js"></script>
     )}
   </Helmet>

--- a/packages/gatsby-theme-aio/src/components/SEO/index.js
+++ b/packages/gatsby-theme-aio/src/components/SEO/index.js
@@ -24,20 +24,23 @@ const SEO = ({ title, description, keywords }) => (
     <link rel="icon" href="https://www.adobe.com/favicon.ico" type="image/x-icon" />
     <link rel="shortcut icon" href="https://www.adobe.com/favicon.ico" type="image/x-icon" />
     {process.env.GATSBY_ADOBE_ANALYTICS_ENV && (
-      <script type="text/javascript">{`
-        window.marketingtech = {
-          'adobe': {
-            'launch': {
-              'property': 'global',
-              'environment': '${process.env.GATSBY_ADOBE_ANALYTICS_ENV || 'dev'}'
-            },
-            'analytics': {
-              'additionalAccounts': '${process.env.GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS || ''}'
+      <React.Fragment>
+        <script type="text/javascript">{`
+          window.marketingtech = {
+            'adobe': {
+              'launch': {
+                'property': 'global',
+                'environment': '${process.env.GATSBY_ADOBE_ANALYTICS_ENV || 'dev'}'
+              },
+              'analytics': {
+                'additionalAccounts': '${process.env.GATSBY_ADDITIONAL_ADOBE_ANALYTICS_ACCOUNTS || ''}'
+              }
             }
-          }
-        };
-      `}</script>
-      <script src="https://www.adobe.com/marketingtech/main.min.js"></script>
+          };
+        `}</script>
+
+        <script src="https://www.adobe.com/marketingtech/main.min.js"></script>
+      </React.Fragment>
     )}
   </Helmet>
 );


### PR DESCRIPTION
## Description

Previously analytics bootstrap script was only loaded based on two env variables that are not present. This cleans up the logic and should cause analytics script to run when both this and https://github.com/AdobeDocs/dev-site/pull/99 are merged.


## Motivation and Context

Switching to global nav.

## How Has This Been Tested?

It hasn't!

