### PR TITLE
fix(DEVSITE-378): penpal timeout in Frame

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Layout/index.js
+++ b/packages/gatsby-theme-aio/src/components/Layout/index.js
@@ -137,12 +137,12 @@ export default ({ children, pageContext, location }) => {
           let IMS_CONFIG_JSON = JSON.parse(IMS_CONFIG);
           IMS_CONFIG_JSON.onReady = () => {
             setIms(window.adobeIMS);
+            setIsLoadingIms(false);
           };
           window.adobeImsFactory.createIMSLib(IMS_CONFIG_JSON);
           window.adobeIMS.initialize();
         } catch (e) {
           console.error(`AIO: IMS error.`);
-        } finally {
           setIsLoadingIms(false);
         }
       })();
@@ -448,6 +448,7 @@ export default ({ children, pageContext, location }) => {
       <Provider
         value={{
           ims,
+          isLoadingIms,
           location,
           pageContext,
           hasSideNav,


### PR DESCRIPTION
This fixes a timeout issue with the penpal library.

## Description

This PR fixes an issue where `connectToChild` could be called after the child's `connectToParent` in the `Frame` component. This caused a child in the `Frame` to time out during connecting, as `coonnectToChild` must be called first as per API docs.

Tested to work with https://github.com/AdobeDocs/photoshop-api

## Related Issue

DEVSITE-378

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
