### PR TITLE
CodeBlock keyboard support and colour contrast fixes

### DIFF
--- a/packages/gatsby-theme-aio/src/components/CodeBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/CodeBlock/index.js
@@ -178,6 +178,9 @@ const CodeBlock = (props) => {
                 border-top-left-radius: 0;
                 border-top-right-radius: 0;
               }
+              & pre.prism-code span:first-child {
+                color: #ffffff;
+              }
             `}
             key={k}
             hidden={!(selectedIndex.tab === i && selectedIndex.language === k)}>

--- a/packages/gatsby-theme-aio/src/components/CodeBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/CodeBlock/index.js
@@ -76,6 +76,16 @@ const CodeBlock = (props) => {
     }
   });
 
+  const handleOnChange = (ref) => {
+    const index = tabs.filter((tab) => tab.current).indexOf(ref);
+    setSelectedIndex({
+      tab: index,
+      // Set language index to 0 when switching between tabs
+      language: 0
+    });
+    positionSelectedTabIndicator(index);
+  };
+
   const backgroundColor = `background-color: var(--spectrum-global-color-gray-${theme === 'light' ? '200' : '50'});`;
 
   return (
@@ -111,14 +121,19 @@ const CodeBlock = (props) => {
                 ref={ref}
                 selected={isSelected}
                 tabIndex={0}
+                onKeyDown={(e) => {
+                  if (e.key === 'ArrowRight') {
+                    e.currentTarget.nextSibling && e.currentTarget.nextSibling.focus();
+                  }
+                  if (e.key === 'ArrowLeft') {
+                    e.currentTarget.previousSibling && e.currentTarget.previousSibling.focus();
+                  }
+                }}
                 onClick={() => {
-                  const index = tabs.filter((tab) => tab.current).indexOf(ref);
-                  setSelectedIndex({
-                    tab: index,
-                    // Set language index to 0 when switching between tabs
-                    language: 0
-                  });
-                  positionSelectedTabIndicator(index);
+                  handleOnChange(ref);
+                }}
+                onFocus={() => {
+                  handleOnChange(ref);
                 }}>
                 <TabsItemLabel>{props[block.heading].props.children}</TabsItemLabel>
               </TabsItem>

--- a/packages/gatsby-theme-aio/src/components/CodeBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/CodeBlock/index.js
@@ -30,6 +30,13 @@ const CodeBlock = (props) => {
   };
 
   useEffect(() => {
+    const codePres = [...document.querySelectorAll('pre.prism-code')];
+    codePres.map((codePre) => {
+      codePre.tabIndex = 0;
+    });
+  }, []);
+
+  useEffect(() => {
     positionSelectedTabIndicator();
   }, [tabs]);
 

--- a/packages/gatsby-theme-aio/src/components/Tabs/index.js
+++ b/packages/gatsby-theme-aio/src/components/Tabs/index.js
@@ -203,6 +203,14 @@ const TabsBlock = ({ theme = 'light', orientation = 'horizontal', className, ...
     const selectedTab = tabs.filter((tab) => tab?.current)[index];
     positionIndicator(selectedTabIndicator, selectedTab);
   };
+
+  const handleOnChange = (index) => {
+    setSelectedIndex({
+      tab: index
+    });
+    positionSelectedTabIndicator(index);
+  };
+
   return (
     <section
       className={classNames(className, `tabsBlock spectrum--${theme}`)}
@@ -247,22 +255,38 @@ const TabsBlock = ({ theme = 'light', orientation = 'horizontal', className, ...
                 const ref = createRef();
                 tabs.push(ref);
                 const isSelected = selectedIndex.tab === index;
-                const itemPopoverId = nextId();
                 return (
                   <Item
                     className={'tabItem'}
                     key={`tabItem_${index}`}
-                    tabIndex={0}
+                    id={`tabItem_${index}`}
                     ref={ref}
                     isSelected={isSelected}
-                    aria-controls={itemPopoverId}
+                    aria-controls={`tabView${index}`}
+                    tabIndex={index === selectedIndex.tab ? 0 : -1}
+                    aria-label={data['heading']}
+                    aria-selected={index === selectedIndex.tab}
                     label={<b>{data['heading']}</b>}
                     icon={data['image']}
+                    onKeyDown={(e) => {
+                      if (e.key === 'ArrowDown' || e.key === 'Enter') {
+                        e.preventDefault();
+                        if (menuItems.length === index + 1 && APIReference !== '') {
+                          document.getElementById('apiReference')?.setAttribute('tabIndex', 0);
+                          document.getElementById('apiReference').focus();
+                        }
+                        e.currentTarget.nextSibling && e.currentTarget.nextSibling.nextSibling.focus();
+                      }
+                      if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        e.currentTarget.previousSibling && e.currentTarget.previousSibling.previousSibling.focus();
+                      }
+                    }}
+                    onFocus={() => {
+                      handleOnChange(index);
+                    }}
                     onClick={() => {
-                      setSelectedIndex({
-                        tab: index
-                      });
-                      positionSelectedTabIndicator(index);
+                      handleOnChange(index);
                     }}
                     css={css`
                       text-align: left;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Added support for keyboard navigation in CodeBlock.

Enabling tab switching and overflow scroll within CodeBlock with arrow buttons.

This was based on fixes applied by the Document Services team in their shadowed components.

In addition adjusted the colour of line number to improve contrast ratio.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This fixes reported accessibility issues in our CodeBlock.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Primarily tested by running scans for accessibility issues using AXE dev tools on /guides/reporting_api/#time-series-reports path of example folder.
## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
