### PR TITLE
fix: update test:e2e to run dev instead of build && serve

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           build: yarn build
           start: yarn serve
+          wait-on: 'http://localhost:9000'
           browser: chrome
           config-file: cypress.config.js
           spec: cypress/e2e/smoke.cy.js

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run Tests
         uses: cypress-io/github-action@v4

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('./cypress/plugins/index.js')(on, config)
     },
-    baseUrl: 'http://localhost:8000',
+    baseUrl: 'http://localhost:9000',
     specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
   },
 })

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -9,7 +9,7 @@ module.exports = defineConfig({
     setupNodeEvents(on, config) {
       return require('./cypress/plugins/index.js')(on, config)
     },
-    baseUrl: 'http://localhost:9000',
+    baseUrl: 'http://localhost:8000',
     specPattern: 'cypress/e2e/**/*.cy.{js,jsx,ts,tsx}',
   },
 })

--- a/cypress/cypress-github-actions.json
+++ b/cypress/cypress-github-actions.json
@@ -1,6 +1,0 @@
-{
-  "baseUrl": "http://localhost:8000",
-  "integrationFolder": "cypress/e2e",
-  "viewportHeight": 900,
-  "viewportWidth": 1440
-}

--- a/cypress/cypress-github-actions.json
+++ b/cypress/cypress-github-actions.json
@@ -1,5 +1,5 @@
 {
-  "baseUrl": "http://localhost:9000",
+  "baseUrl": "http://localhost:8000",
   "integrationFolder": "cypress/e2e",
   "viewportHeight": 900,
   "viewportWidth": 1440

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "clean": "yarn workspace example clean",
     "format": "npx prettier --write '**/*.{js,json}'",
     "cy:open": "cypress open",
-    "test:e2e": "start-server-and-test dev http://localhost:8000 cy:open"
+    "test:e2e": "start-server-and-test start http://localhost:9000 cy:open"
   },
   "packageManager": "yarn@3.2.1"
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixed e2e test so that it runs gatsby develop (dev) on port 8000 instead of gatsby build && serve on port 9000. 

## Motivation and Context

Fixing side effects of updating cypress packages to the latest versions.

## How Has This Been Tested?

Tested the cypress smoke test locally by running `yarn test:e2e`

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
