### PR TITLE
fix: add path key with relative path to search records

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -11,6 +11,7 @@
     "start:prefix": "gatsby build --prefix-paths && gatsby serve --prefix-paths",
     "develop": "gatsby develop --host 0.0.0.0",
     "develop:https": "gatsby develop --https --host localhost.corp.adobe.com --port 9000",
+    "develop:schema": "GATSBY_GRAPHQL_IDE=playground gatsby develop",
     "build": "gatsby build",
     "serve": "gatsby serve",
     "clean": "gatsby clean"

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev": "yarn workspace example develop",
     "dev:clean": "yarn workspace example clean && yarn workspace example develop",
     "dev:https": "yarn workspace example develop:https",
+    "dev:schema": "yarn workspace example develop:schema",
     "build": "yarn workspace example build",
     "build:incremental": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true yarn workspace example build --log-pages",
     "serve": "yarn workspace example serve",

--- a/packages/gatsby-theme-aio/algolia/create-record.js
+++ b/packages/gatsby-theme-aio/algolia/create-record.js
@@ -14,9 +14,6 @@ const { getAdobeDocType } = require("./helpers/get-adobe-doctype");
 
 async function createRecord(rawRecord, file) {
   const record = {
-    anchor: rawRecord.anchor,
-    birthTime: file.birthTime,
-    changeTime: file.changeTime,
     category: getCategory(file.category),
     content: rawRecord.content,
     contentDigest: rawRecord.contentDigest,
@@ -24,15 +21,15 @@ async function createRecord(rawRecord, file) {
     description: rawRecord.description,
     excerpt: file.excerpt,
     featured: file.featured,
-    fileAbsolutePath: file.fileAbsolutePath,
     headings: rawRecord.headings,
+    howRecent: getHowRecent(file.changeTime),
+    icon: file.icon,
+    isNew: getIsNew(file.birthTime),
     keywords: getKeywords(file.keywords),
     lastUpdated: file.lastUpdated,
-    isNew: file.isNew,
-    howRecent: file.howRecent,
     objectID: rawRecord.objectID,
+    path: getPath(rawRecord, file),
     product: file.product,
-    icon: file.icon,
     size: file.size,
     slug: file.slug,
     title: rawRecord.title,
@@ -40,6 +37,16 @@ async function createRecord(rawRecord, file) {
     words: rawRecord.words,
   };
   return record;
+}
+
+function getIsNew(birthTimeInDays) {
+  const days = parseInt(birthTimeInDays, 10);
+  return days <= 30;
+}
+
+function getHowRecent(lastUpdatedInDays) {
+  const days = parseInt(lastUpdatedInDays, 10);
+  return days <= 30 ? 3 : days <= 60 ? 2 : days <= 90 ? 1 : 0;
 }
 
 // We use the standard documentation types from Experience League to tag our markdown files with the category frontmatter.
@@ -55,8 +62,13 @@ function getKeywords(keywords) {
 
 // Full url complete with anchor link to the nearest heading for the search record result.
 function getUrl(rawRecord, file) {
-  return `${process.env.GATSBY_SITE_DOMAIN_URL}${process.env.PATH_PREFIX}${file.slug == null ? '' : file.slug
+  return `${process.env.GATSBY_SITE_DOMAIN_URL}${file.pathPrefix}${file.slug == null ? '' : file.slug
     }${rawRecord.anchor}`;
+}
+
+function getPath(rawRecord, file) {
+  return `${file.pathPrefix}${file.slug == null ? '' : file.slug
+  }${rawRecord.anchor}`;
 }
 
 module.exports = createRecord;

--- a/packages/gatsby-theme-aio/algolia/helpers/get-content-from-cache.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/get-content-from-cache.js
@@ -17,17 +17,16 @@ const { existsSync, readFileSync } = require('fs');
  * Support of "frameSrc" directive:
  * https://github.com/adobe/aio-theme#frame
  */
-function getContentFromCache(node, options) {
-  const { fileAbsolutePath } = node;
+function getContentFromCache(markdownFile, options) {
+  const { fileAbsolutePath } = markdownFile;
   const [siteDirAbsolutePath] = normalizePath(fileAbsolutePath).split(options.pagesSourceDir);
-  const staticFileAbsolutePath = `${siteDirAbsolutePath}${options.staticSourceDir}${node.frameSrc}`;
+  const staticFileAbsolutePath = `${siteDirAbsolutePath}${options.staticSourceDir}${markdownFile.frameSrc}`;
 
   if (!existsSync(staticFileAbsolutePath)) {
     throw Error(`Static file resolving error: no such file "${staticFileAbsolutePath}"`);
   }
 
-  const fileContent = readFileSync(staticFileAbsolutePath, 'utf8');
-  return fileContent;
+  return readFileSync(staticFileAbsolutePath, 'utf8');
 }
 
 module.exports = getContentFromCache;

--- a/packages/gatsby-theme-aio/algolia/helpers/get-iframe-content.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/get-iframe-content.js
@@ -18,8 +18,8 @@ const getContentFromCache = require('./get-content-from-cache');
  * https://github.com/adobe/aio-theme#frame
  */
 
-async function getIFrameContent(node) {
-  if (!node.frameSrc) return null;
+async function getIFrameContent(markdownFile) {
+  if (!markdownFile.frameSrc) return null;
 
   const options = {
     pagesSourceDir: 'src/pages',
@@ -29,9 +29,9 @@ async function getIFrameContent(node) {
     minWordsCount: 3,
   };
 
-  const content = /^https?:\/\//i.test(node.frameSrc)
-    ? await getContentFromUrl(node.frameSrc)
-    : getContentFromCache(node, options);
+  const content = /^https?:\/\//i.test(markdownFile.frameSrc)
+    ? await getContentFromUrl(markdownFile.frameSrc)
+    : getContentFromCache(markdownFile, options);
 
   return { content, options };
 }

--- a/packages/gatsby-theme-aio/algolia/helpers/get-openapi-content.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/get-openapi-content.js
@@ -19,8 +19,8 @@ const exec = require('await-exec');
  * https://github.com/adobe/aio-theme#openapi
  */
 
-async function getOpenApiContent(node) {
-  if (!node.openAPISpec) return null;
+async function getOpenApiContent(markdownFile) {
+  if (!markdownFile.openAPISpec) return null;
 
   const tempDir = './public/redoc';
   const options = {
@@ -31,7 +31,7 @@ async function getOpenApiContent(node) {
   };
 
   const redoc = require.resolve('redoc-cli');
-  const { openAPISpec } = node;
+  const { openAPISpec } = markdownFile;
   const spec = openAPISpec.startsWith('/') ? join('static', openAPISpec) : openAPISpec;
   const htmlFile = join(options.tempDir, 'index.html');
 

--- a/packages/gatsby-theme-aio/algolia/helpers/get-products-indexes.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/get-products-indexes.js
@@ -51,12 +51,10 @@ const adobeProducts = {
   adobe_workfront: 'Adobe Workfront',
   adobe_xd: 'Adobe XD',
   adobe_xmp: 'Adobe XMP',
-  aio_theme: 'Adobe Theme Example', // For testing only
 };
 
 // Algolia adobeIndexes for Adobe products documentation.
 const adobeIndexes = {
-  aio_theme: 'aio-theme',
   adobe_dev_console: 'adobe-dev-console',
   adobe_io_events: 'adobe-io-events',
   adobe_io_runtime: 'adobe-io-runtime',
@@ -120,7 +118,8 @@ const adobeIndexes = {
 };
 
 const getProductFromIndex = index => {
-  return {
+  index = index.replace(/([a-zA-Z].+\/)/, '');
+  const products = {
     'after-effects': adobeProducts.adobe_after_effects,
     'analytics-2.0-apis': adobeProducts.adobe_analytics,
     animate: adobeProducts.adobe_animate,
@@ -181,12 +180,14 @@ const getProductFromIndex = index => {
     xd: adobeProducts.adobe_xd,
     'uxp-xd': adobeProducts.adobe_xd,
     'xmp-docs': adobeProducts.adobe_xmp,
-    'aio-theme': adobeProducts.aio_theme,
+    'default': '',
   }[index];
+
+  return products[index] ? products[index] : products['default'];
 };
 
 const getIndexesFromProduct = product => {
-  return {
+  const indexes = {
     'Adobe After Effects': [adobeIndexes.after_effects],
     'Adobe Analytics': [adobeIndexes.analytics_2_0_apis],
     'Adobe Animate': [adobeIndexes.animate],
@@ -254,7 +255,10 @@ const getIndexesFromProduct = product => {
     'Adobe Workfront': [adobeIndexes.wf_apis, adobeIndexes.workfront_api_explorer],
     'Adobe XD': [adobeIndexes.xd, adobeIndexes.uxp_xd],
     'Adobe XMP': [adobeIndexes.xmp_docs],
+    'default': [''],
   }[product];
+
+  return indexes[product] ? indexes[product] : indexes['default'];
 };
 
 module.exports = {

--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -25,36 +25,37 @@ function indexRecords() {
       query: mdxQuery,
       transformer: async function ({
         data: {
+          site: { pathPrefix },
+          github: { repository },
           allFile: { nodes },
         },
       }) {
         const markdownFiles = [];
         for (const node of nodes) {
-          // Creates flattened objects from the mdxQuery source data (markdown files in src/pages).
           markdownFiles.push({
-            objectID: node.id,
-            contentDigest: node.internal.contentDigest,
-            product: getProductFromIndex(process.env.REPO_NAME),
             birthTime: node.birthTime,
+            category: node.childMdx.frontmatter.category,
             changeTime: node.changeTime,
-            lastUpdated: node.modifiedTime,
-            size: node.size,
-            isNew: node.isNew,
+            description: node.childMdx.frontmatter.description,
+            excerpt: node.childMdx.excerpt,
+            featured: node.childMdx.frontmatter.featured,
+            fileAbsolutePath: node.childMdx.fileAbsolutePath,
+            frameSrc: node.childMdx.frontmatter.frameSrc,
+            headings: node.childMdx.headings,
             howRecent: node.howRecent,
             icon: node.icon,
-            headings: node.childMdx.headings,
-            excerpt: node.childMdx.excerpt,
-            words: node.childMdx.wordCount.words,
-            fileAbsolutePath: node.childMdx.fileAbsolutePath,
+            isNew: node.isNew,
+            keywords: node.childMdx.frontmatter.keywords,
+            lastUpdated: node.modifiedTime,
+            mdxAST: node.childMdx.mdxAST,
+            objectID: node.id,
+            openAPISpec: node.childMdx.frontmatter.openAPISpec,
+            pathPrefix: `${pathPrefix}/`,
+            product: getProductFromIndex(repository),
+            size: node.size,
             slug: node.childMdx.slug,
             title: node.childMdx.frontmatter.title,
-            description: node.childMdx.frontmatter.description,
-            keywords: node.childMdx.frontmatter.keywords,
-            category: node.childMdx.frontmatter.category,
-            openAPISpec: node.childMdx.frontmatter.openAPISpec,
-            frameSrc: node.childMdx.frontmatter.frameSrc,
-            featured: node.childMdx.frontmatter.featured,
-            mdxAST: node.childMdx.mdxAST,
+            words: node.childMdx.wordCount.words,
           });
         }
 

--- a/packages/gatsby-theme-aio/algolia/index-settings.js
+++ b/packages/gatsby-theme-aio/algolia/index-settings.js
@@ -3,9 +3,9 @@ const indexSettings = () => {
     searchableAttributes: [
       'title',
       'contentHeading',
+      'unordered(content)',
       'unordered(description)',
       'unordered(excerpt)',
-      'unordered(content)',
     ],
     advancedSyntax: true,
     allowTyposOnNumericTokens: true,

--- a/packages/gatsby-theme-aio/algolia/mdx-query.js
+++ b/packages/gatsby-theme-aio/algolia/mdx-query.js
@@ -11,7 +11,13 @@
  */
 
 const mdxQuery = `
-  {
+{
+  site {
+    pathPrefix
+  }
+  github {
+    repository
+  },
   allFile(
     filter: {absolutePath: {regex: "/src/pages/"}, internal: {mediaType: {in: ["text/markdown", "text/mdx", "text/x-markdown"]}}}
   ) {
@@ -20,12 +26,12 @@ const mdxQuery = `
       internal {
         contentDigest
       }
-      birthTime
-      changeTime
+      birthTime(difference: "days")
+      changeTime(difference: "days")
+      modifiedTime(fromNow: true)
+      icon
       isNew
       howRecent
-      icon
-      modifiedTime(fromNow: true)
       size
       childMdx {
         excerpt(pruneLength: 200)
@@ -36,7 +42,14 @@ const mdxQuery = `
           category
           featured
           openAPISpec
+          jsDoc
           frameSrc
+          frameHeight
+          contributors
+          edition
+          hideBreadcrumbNav
+          contributor_name
+          contributor_link
         }
         headings {
           value

--- a/packages/gatsby-theme-aio/gatsby-node.js
+++ b/packages/gatsby-theme-aio/gatsby-node.js
@@ -34,84 +34,85 @@ exports.onCreateWebpackConfig = ({ actions }) => {
 };
 
 exports.createSchemaCustomization = ({ actions }) => {
-  const { createTypes } = actions;
+  const { createTypes } = actions; // define custom types
 
-  const typeDefs = `
-    type Link {
-      title: String
-      path: String
-    }
-
-    type Menu {
+  createTypes(`
+      type SiteSiteMetadata implements Node @dontInfer {
       title: String
       description: String
-      path: String
-    }
-
-    type TopPage {
-      title: String
-      path: String
-      menu: [Menu]
-    }
-
-    type Version {
-      title: String
-      path: String
-      selected: Boolean
-    }
-
-    type Home {
-      title: String
-      path: String
-      hidden: Boolean
-    }
-
-    type SiteSiteMetadata {
       home: Home
       pages: [TopPage]
       subPages: [SubPage]
       versions: [Version]
       docs: Link
     }
-
-    type SubPage {
+    
+    type Home @dontInfer {
+      title: String
+      path: String
+      hidden: Boolean
+    }
+    
+    type TopPage @dontInfer {
+      title: String
+      path: String
+      menu: [Menu]
+    }
+    
+    type Menu @dontInfer {
+      title: String
+      description: String
+      path: String
+    }
+    
+    type SubPage @dontInfer {
       title: String
       path: String
       header: Boolean
       pages: [NestedSubPage1]
     }
-
-    type NestedSubPage1 {
+    
+    type NestedSubPage1 @dontInfer {
       title: String
       path: String
       pages: [NestedSubPage2]
     }
 
-    type NestedSubPage2 {
+    type NestedSubPage2 @dontInfer {
       title: String
       path: String
       pages: [NestedSubPage3]
     }
 
-    type NestedSubPage3 {
+    type NestedSubPage3 @dontInfer {
       title: String
       path: String
       pages: [NestedSubPage4]
     }
 
-    type NestedSubPage4 {
+    type NestedSubPage4 @dontInfer {
       title: String
       path: String
       pages: [NestedSubPage5]
     }
 
-    type NestedSubPage5 {
+    type NestedSubPage5 @dontInfer {
       title: String
       path: String
       pages: [Link]
     }
-  `;
-  createTypes(typeDefs);
+    
+    type Version @dontInfer {
+      title: String
+      path: String
+      selected: Boolean
+    }
+        
+    type Link @dontInfer {
+      title: String
+      path: String
+    }
+  `);
 };
 
 exports.createResolvers = ({ createResolvers }) => {
@@ -119,119 +120,81 @@ exports.createResolvers = ({ createResolvers }) => {
     File: {
       isNew: {
         type: 'Boolean',
-        resolve(source) {
-          const birthTime = new Date(source.birthTime);
-          const publishDate = birthTime.getTime();
-          const daysPassed = Math.floor((Date.now() - publishDate) / 1000 / 60 / 60 / 24);
-          return daysPassed <= 60; // 60 days
-        }
+        resolve: source => source.isNew,
       },
       howRecent: {
         type: 'Int',
-        resolve(source, args, context, info) {
-          const changeTime = new Date(source.changeTime);
-          const timeUpdated = changeTime.getTime();
-          const daysPassed = Math.floor((Date.now() - timeUpdated) / 1000 / 60 / 60 / 24);
-          return daysPassed <= 30 ? 3 : daysPassed <= 60 ? 2 : daysPassed <= 120 ? 1 : 0;
-        },
+        resolve: source => source.howRecent || 0,
       },
       icon: {
         type: 'String',
-        resolve(source) {
-          return source.icon;
-        }
+        resolve: source => source.icon || '',
+      },
+      path: {
+        type: 'String',
+        resolve: source => source.path || '',
       },
     },
     MdxFrontmatter: {
       title: {
         type: 'String',
-        resolve(source) {
-          return source.title;
-        }
+        resolve: source => source.title,
       },
       keywords: {
         type: '[String]',
-        resolve(source) {
-          return source.keywords;
-        }
+        resolve: source => source.keywords,
       },
       category: {
         type: 'String',
-        resolve(source) {
-          return source.category;
-        }
+        resolve: source => source.category,
       },
       description: {
         type: 'String',
-        resolve(source) {
-          return source.description;
-        }
+        resolve: source => source.description,
       },
       contributors: {
         type: '[String]',
-        resolve(source) {
-          return source.contributors;
-        }
-      },
-      contributor_name: {
-        type: 'String',
-        resolve(source) {
-          return source.contributor_name;
-        }
+        resolve: source => source.contributors
       },
       contributor_link: {
         type: 'String',
-        resolve(source) {
-          return source.contributor_link;
-        }
+        resolve: source => source.contributor_link,
+      },
+      contributor_name: {
+        type: 'String',
+        resolve: source => source.contributor_name,
       },
       edition: {
         type: 'String',
-        resolve(source) {
-          return source.edition;
-        }
+        resolve: source => source.edition,
       },
       openAPISpec: {
         type: 'String',
-        resolve(source) {
-          return source.openAPISpec;
-        }
+        resolve: source => source.openAPISpec,
       },
       frameSrc: {
         type: 'String',
-        resolve(source) {
-          return source.frameSrc;
-        }
+        resolve: source => source.frameSrc,
       },
       frameHeight: {
         type: 'String',
-        resolve(source) {
-          return source.frameHeight;
-        }
+        resolve: source => source.frameHeight,
       },
       layout: {
         type: 'String',
-        resolve(source) {
-          return source.layout;
-        }
+        resolve: source => source.layout,
       },
       jsDoc: {
         type: 'Boolean',
-        resolve(source) {
-          return source.jsDoc;
-        }
+        resolve: source => source.jsDoc,
       },
       hideBreadcrumbNav: {
         type: 'Boolean',
-        resolve(source) {
-          return source.hideBreadcrumbNav;
-        }
+        resolve: source => source.hideBreadcrumbNav,
       },
       featured: {
         type: 'Boolean',
-        resolve(source) {
-          return source.featured;
-        }
+        resolve: source => source.featured || false,
       },
     },
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a `path` key to all the search record objects for use on the frontend. Additionally, this PR:
- Refactors our custom graphql schema code in `gatsby-node.js` to return defaults and ensure our custom types are being resolved correctly.
- Adds default return values (currently null) to `getProductFromIndex()` and `getIndexesFromProduct()` when there is no matching product or index passed in.
- Removes the product and index from the theme's example project.

## Related Issue

The relative path property was found to be missing during frontend testing.

## Motivation and Context

Ensuring frontend code has all the data it needs from the search records.

## How Has This Been Tested?

Ran updates again `example` project and monitored the results on Algolia servers.

## Screenshots (if appropriate):

Showing all record properties available to frontend:

<img width="1111" alt="image" src="https://user-images.githubusercontent.com/1828494/189963568-e8e5d031-b551-4564-8ac3-80b0ccf3dbfb.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
