### PR TITLE
fix: allow schema inferences from theme consumers

### DIFF
--- a/packages/gatsby-theme-aio/algolia/helpers/html-parser.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/html-parser.js
@@ -83,7 +83,7 @@ module.exports = class HtmlParser {
       const item = {
         html: this.extractHtml(node),
         content,
-        description: content,
+        description: content.substring(0, 200),
         headings: Object.values(currentHierarchy).filter(h => h),
         node,
         customRanking: {

--- a/packages/gatsby-theme-aio/algolia/helpers/parse-mdx.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/parse-mdx.js
@@ -67,9 +67,7 @@ function getContentHeading(mdastNode, markdownFile, minCharLength) {
 
   const filteredHeadings = allHeadings
     .filter(heading => heading.position.start.line < contentPositionEndLine)
-    .filter(
-      heading => heading.children[0].value !== 'Request' && heading.children[0].value !== 'Response'
-    );
+    .filter(heading => heading.depth > 4);
 
   const headingsAboveContent = [];
   for (const heading of filteredHeadings) {

--- a/packages/gatsby-theme-aio/gatsby-node.js
+++ b/packages/gatsby-theme-aio/gatsby-node.js
@@ -37,7 +37,7 @@ exports.createSchemaCustomization = ({ actions }) => {
   const { createTypes } = actions; // define custom types
 
   createTypes(`
-      type SiteSiteMetadata implements Node @dontInfer {
+      type SiteSiteMetadata implements Node {
       title: String
       description: String
       home: Home
@@ -46,69 +46,69 @@ exports.createSchemaCustomization = ({ actions }) => {
       versions: [Version]
       docs: Link
     }
-    
-    type Home @dontInfer {
+
+    type Home {
       title: String
       path: String
       hidden: Boolean
     }
-    
-    type TopPage @dontInfer {
+
+    type TopPage {
       title: String
       path: String
       menu: [Menu]
     }
-    
-    type Menu @dontInfer {
+
+    type Menu {
       title: String
       description: String
       path: String
     }
-    
-    type SubPage @dontInfer {
+
+    type SubPage {
       title: String
       path: String
       header: Boolean
       pages: [NestedSubPage1]
     }
-    
-    type NestedSubPage1 @dontInfer {
+
+    type NestedSubPage1 {
       title: String
       path: String
       pages: [NestedSubPage2]
     }
 
-    type NestedSubPage2 @dontInfer {
+    type NestedSubPage2 {
       title: String
       path: String
       pages: [NestedSubPage3]
     }
 
-    type NestedSubPage3 @dontInfer {
+    type NestedSubPage3 {
       title: String
       path: String
       pages: [NestedSubPage4]
     }
 
-    type NestedSubPage4 @dontInfer {
+    type NestedSubPage4 {
       title: String
       path: String
       pages: [NestedSubPage5]
     }
 
-    type NestedSubPage5 @dontInfer {
+    type NestedSubPage5 {
       title: String
       path: String
       pages: [Link]
     }
-    
-    type Version @dontInfer {
+
+    type Version {
       title: String
       path: String
       selected: Boolean
     }
-        
-    type Link @dontInfer {
+
+    type Link {
       title: String
       path: String
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR reopens the theme's custom schema from consumer projects by allowing Gatsby to infer the schema as projects add to it.

## Related Issue

Some projects that use the theme added additional schema nodes that require us to keep it open by letting Gatsby infer additional custom schema types.

## Motivation and Context

Projects that add their own schema nodes are not permitted to do so when the `@dontInfer` directive is added. The reason for adding this directive was to speed up build times. For full details, see: https://www.gatsbyjs.com/docs/reference/graphql-data-layer/schema-customization/#opting-out-of-type-inference

## How Has This Been Tested?

Tested against all the projects that threw errors during reindexing.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
