### PR TITLE
fix: fix apiKey name to match name in deploy.yml

### DIFF
--- a/packages/gatsby-theme-aio/gatsby-config.js
+++ b/packages/gatsby-theme-aio/gatsby-config.js
@@ -134,7 +134,7 @@ module.exports = {
       options: {
         appId: process.env.GATSBY_ALGOLIA_APPLICATION_ID,
         indexName: process.env.GATSBY_ALGOLIA_INDEX_NAME,
-        apiKey: process.env.ALGOLIA_ADMIN_API_KEY,
+        apiKey: process.env.ALGOLIA_WRITE_API_KEY,
         queries: indexRecords(),
         chunkSize: 1000,
         algoliasearchOptions: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR fixes a mistaken name change to the `apiKey` of the `gatsby-plugin-algolia` plugin within the `gatsby-config.js` file. 

## Related Issue

I am not aware of any related Jira issue. Please create one and add it here if there is not one already.

## Motivation and Context

About two hours ago, Jeff made me aware that indexing was not working when deploying a site from the GitHub deploy workflow. So I saw the issue after examining the log of a test deployment and seeing this line: https://github.com/AdobeDocs/commerce-frontend-core/actions/runs/3145717529/jobs/5113345044#step:10:74

We've all seen and discussed this `.env` variable problem before: `api key or appId are missing; skipping ***ing`. After discovering that, the `.env` variable name mismatch between the `gatsby-config.js` and the GitHub action secret became the first thing to check. 

## How Has This Been Tested?

I used the `ALGOLIA_WRITE_API_KEY` `.env` variable (the one that matches the variable name in the `deploy.yml` workflow) to build the `commerce-frontend-core` site locally, then viewed its index in the list of most currently built Algolia indexes:

<img width="1065" alt="image" src="https://user-images.githubusercontent.com/1828494/192865955-665a2c4a-e5c0-45c0-a785-f5bb7a7d8536.png">

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
