### PR TITLE
Devsite-524-tab-block-enhancement

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Tabs/index.js
+++ b/packages/gatsby-theme-aio/src/components/Tabs/index.js
@@ -249,6 +249,9 @@ const TabsBlock = ({ theme = 'light', orientation = 'horizontal', className, ...
               width: ${layoutColumns(8)} !important;
             }
           `}>
+          <div  css={css`
+            ${menuItems?.length > 6 ? 'overflow-x:auto; overflow-y: hidden;' : ''}
+            `}>
           {menuItems?.length > 0 ? (
             <Tabs orientation={orientation} isQuiet={true} onFontsReady={positionSelectedTabIndicator}>
               {menuItems.map((data, index) => {
@@ -327,6 +330,7 @@ const TabsBlock = ({ theme = 'light', orientation = 'horizontal', className, ...
               <TabsIndicator ref={selectedTabIndicator} />
             </Tabs>
           ) : null}
+          </div>
           {menuItems?.length > 0
             ? menuItems.map((data, index) => {
                 const isHidden = selectedIndex.tab === index;


### PR DESCRIPTION
Adding the tabs to support 8 tabs with a scroll bar.

<!--- Provide a general summary of your changes in the Title above -->

## Description
When the tab size is bigger than 6, scrollbar will be enabled automatically. 
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-524
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
To support GitBook of having more than 6 tabs. 
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I've tested it through adding my local changes into the aep-mobile-sdkdocs repo to reflect the changes.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screen Shot 2022-10-20 at 12 40 56 PM](https://user-images.githubusercontent.com/14320591/197042459-43a4bb25-2175-417c-8377-380316a07e46.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
