### PR TITLE
Adding nested indicator for sideNav.

### DIFF
--- a/packages/gatsby-theme-aio/src/components/SideNav/index.js
+++ b/packages/gatsby-theme-aio/src/components/SideNav/index.js
@@ -18,6 +18,7 @@ import { css } from '@emotion/react';
 import classNames from 'classnames';
 import '@spectrum-css/sidenav';
 import nextId from 'react-id-generator';
+import {ChevronRight} from "../Icons";
 
 const SideNav = ({ selectedPages, selectedSubPages, setShowSideNav }) => {
   const [expandedPages, setExpandedPages] = useState([]);
@@ -83,6 +84,15 @@ const SideNav = ({ selectedPages, selectedSubPages, setShowSideNav }) => {
                 to={page.href}
                 className="spectrum-SideNav-itemLink">
                 {page.title}
+                {page.pages && page.pages.length > 0 ? <ChevronRight
+                  css={css` position:absolute; right:0px;
+                            width: var(--spectrum-global-dimension-size-125) !important;
+                            height: var(--spectrum-global-dimension-size-125) !important;
+                            margin-left: var(--spectrum-global-dimension-size-100);
+                            transition: transform var(--spectrum-global-animation-duration-100) ease-in-out;
+                            ${expandedPages.includes(page.href) && `transform: rotate(90deg);`}
+                          `}
+                /> : null}
               </GatsbyLink>
             )}
             {page.pages && (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adding a indicator to show there is nested items

## Description
Adding a chevron right icon that will display only when there is item to show when there is nested items.  It will rotate with when it is expand or collapse.  
<!--- Describe your changes in detail -->

## Related Issue
It's a new feature requested by the mobile team to show the nested items with indictor. 
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I linked my change to the mobile sdk pages to make sure the indicator shows up properly. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![Screen Shot 2022-11-01 at 11 36 04 AM](https://user-images.githubusercontent.com/14320591/199311645-e958d150-c5de-4c27-9bac-3b0bbfdeb415.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
