### PR TITLE
Enhancement for Side Nav bar.

### DIFF
--- a/packages/gatsby-theme-aio/src/components/GlobalHeader/index.js
+++ b/packages/gatsby-theme-aio/src/components/GlobalHeader/index.js
@@ -78,10 +78,6 @@ const getAvatar = async (userId) => {
   }
 };
 
-const toggleSideNavExpanded = (setSideNavExpanded) => {
-  setSideNavExpanded((sideNavExpanded) => !sideNavExpanded);
-};
-
 const GlobalHeader = ({
   hasIMS,
   ims,
@@ -125,6 +121,10 @@ const GlobalHeader = ({
     if (selectedTab?.current) {
       positionIndicator(selectedTabIndicatorRef, selectedTab);
     }
+  };
+
+  const toggleSideNavExpanded = () => {
+    setSideNavExpanded(!sideNavExpanded);
   };
 
   useEffect(() => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Make sure Collapse and Expand works when the user click on the menu. 

## Description
The side nav bar was not able to collapse and expand properly.  The fix is to make sure the click on the menu will collapse and expand will make sure it's being collapsed and expanded every click.

<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-426
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
The 

## How Has This Been Tested?
I've deploy my changes locally to the other repos such as mobile sdk and uxp repos. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
