### PR TITLE
fix(DEVSITE-600): frame no longer supported relative paths

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Frame/index.js
+++ b/packages/gatsby-theme-aio/src/components/Frame/index.js
@@ -53,7 +53,7 @@ const Frame = ({ src, height = 'calc(100vh - var(--spectrum-global-dimension-siz
       // The iframe to which a connection should be made
       iframe: iframe.current,
       // Manually set origin as auto-detection may fail, as the src of the iframe is set later
-      childOrigin: new URL(iframeSrc).origin,
+      childOrigin: isExternalLink(src) ? new URL(src).origin : window.origin,
       // Methods the parent is exposing to the child
       methods: {
         scrollTop(position = 0) {


### PR DESCRIPTION
Fixes issue where `Frame` component no longer supported relative pathnames like `/include.html`.

## Description

Since this change: https://github.com/adobe/aio-theme/pull/833/files#diff-e7e3bc67be10b26102ec899e870d38cde494b9618cda1c96edb9e5d508364410R56 , the frame component crashed when used with a pathname like `/include.html` instead of `https://complete.path.to/include.html`.

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-600

## Motivation and Context

Bug report following https://cq-dev.slack.com/archives/C01GU3V8XE0/p1668099022338219

## How Has This Been Tested?

Tested with the repository where the bug was discovered: https://github.com/AdobeDocs/commerce-webapi/pull/55/files now works as intended on the page `/graphql/reference/`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
