### PR TITLE
Fix Double Breadcrumb issue

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Breadcrumbs/index.js
+++ b/packages/gatsby-theme-aio/src/components/Breadcrumbs/index.js
@@ -20,7 +20,7 @@ const Breadcrumbs = ({ pages }) => (
   <nav aria-label="Breadcrumb" role="navigation">
     <ul className="spectrum-Breadcrumbs spectrum-Breadcrumbs--sizeM">
       {pages.map((page, index) =>
-        page ? (
+        page && !page.header ? (
           <li className="spectrum-Breadcrumbs-item spectrum-Breadcrumbs--sizeM" key={index}>
             <GatsbyLink className="spectrum-Breadcrumbs-itemLink" to={page.href}>
               {page.title}

--- a/packages/gatsby-theme-aio/src/components/MDXFilter/index.js
+++ b/packages/gatsby-theme-aio/src/components/MDXFilter/index.js
@@ -316,16 +316,18 @@ export default ({ children, pageContext, query }) => {
                           <Breadcrumbs
                             pages={[
                               DEFAULT_HOME,
-                              { ...siteMetadata?.pages?.[0], href: withPrefix(siteMetadata?.pages?.[0]?.href) },
+                              siteMetadata?.pages?.length > 1 ? { ...siteMetadata?.pages?.[0], href: withPrefix(siteMetadata?.pages?.[0]?.href) } : null,
                               { ...selectedTopPage, href: withPrefix(selectedTopPage.href) },
                               selectedTopPageMenu && {
                                 ...selectedTopPageMenu,
                                 href: withPrefix(selectedTopPageMenu.href)
                               },
-                              ...selectedSubPages.map((page) => ({
-                                ...page,
-                                href: withPrefix(cleanRootFix(page.href))
-                              }))
+                              ...selectedSubPages.map((page) => page.title === selectedTopPage?.title && page.href === selectedTopPage?.href ? null :
+                                   ({
+                                    ...page,
+                                    href: withPrefix(cleanRootFix(page.href))
+                                  })
+                              )
                             ]}
                           />
                         )}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
when it is a header, do not add a breadcrumb.  Also if it's the same title and same path, we will not add a breadcrumb as well. 
## Description

<!--- Describe your changes in detail -->
Need to make sure when it is a header, do not add a breadcrumb.  Also if it's the same title and same path, we will not add a breadcrumb as well.  

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-426
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested with the two other repo in mobile sdks and photoshop api. 
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
