### PR TITLE
annoucement button fix

### DIFF
--- a/packages/gatsby-theme-aio/src/components/AnnouncementBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/AnnouncementBlock/index.js
@@ -18,8 +18,7 @@ import PropTypes from 'prop-types';
 import { getElementChild, TABLET_SCREEN_WIDTH } from '../../utils';
 import classNames from 'classnames';
 
-const AnnouncementBlock = ({ className, heading, text, button, theme = 'light',   variantsTypePrimary='accent',
-variantsTypeSecondary='secondary',variantStyleFill = "fill",variantStyleOutline = "outline" }) => {
+const AnnouncementBlock = ({ className, heading, text, button, theme = 'light', variantsTypePrimary='primary', variantStyleOutline = "outline" }) => {
 
   const link = getElementChild(button);
 
@@ -67,8 +66,8 @@ variantsTypeSecondary='secondary',variantStyleFill = "fill",variantStyleOutline 
             css={css`
               margin-top: var(--spectrum-global-dimension-size-200);
             `}>
-            <AnchorButton href={link.props.href}  styles={[variantStyleFill, variantStyleOutline]}
-              variants={[variantsTypePrimary,variantsTypeSecondary]}>
+            <AnchorButton href={link.props.href}  style={variantStyleOutline}
+              variant={variantsTypePrimary}>
               <span class="spectrum-Button-label">{link.props.children}</span>
             </AnchorButton>
           </div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The Annoucement block is not taking the style and variants in when it's internal links. 
## Description
Fix the problem by making sure the style and variants aren't an array.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
