### PR TITLE
update cookie preference keyboard

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Footer/index.js
+++ b/packages/gatsby-theme-aio/src/components/Footer/index.js
@@ -457,7 +457,12 @@ const Footer = ({ hasSideNav = false }) => (
                   return (
                     <li key={i}>
                       <Link isQuiet={true} variant="secondary">
-                        <a id={OPEN_PRIVACY_ID} href={path} aria-label="Cookie preferences" tabindex="0"></a>
+                        <a id={OPEN_PRIVACY_ID}  css={css`
+                           &:focus {
+                              text-decoration: underline;
+                              text-decoration-style: double;
+                          }
+                        `} href={path} aria-label="Cookie preferences" tabindex="0"></a>
                       </Link>
                     </li>
                   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The css of focus on the link of cookie preference text-decoration is being override from the third party style. 

## Description
Put inline css style to try override back the style so the when it's in focus, it'll should double underline.
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/A11Y-5429

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
