### PR TITLE
specific fix for mobile-sdk team's path structure.

### DIFF
--- a/packages/gatsby-theme-aio/src/components/GatsbyLink/index.js
+++ b/packages/gatsby-theme-aio/src/components/GatsbyLink/index.js
@@ -49,6 +49,7 @@ const GatsbyLink = forwardRef(({ className, style, variant, to, ...props }, ref)
   }
 
   // Support external relative links and linked files
+  // Not going to replace the path if it's for mobile sdk path of 'client-sdks' as their structure is setup differently.
   return (
     <a
       className={classNames(className)}
@@ -56,7 +57,7 @@ const GatsbyLink = forwardRef(({ className, style, variant, to, ...props }, ref)
         to &&
         !new URL(to, 'https://example.com').pathname.split('.')[1] &&
         pathPrefix &&
-        to.startsWith(trailingSlashFix(pathPrefix))
+        to.startsWith(trailingSlashFix(pathPrefix)) && !to.startsWith("/client-sdks")
           ? to.replace(pathPrefix, '')
           : to
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
GatsbyLink is replacing all path structure which is same pathPrefix. 

## Description
The fix needs to be only for mobile sdk team where the pathPrefix is client-sdks then it will not replace the path structure. 
<!--- Describe your changes in detail -->

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-636

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
