### PR TITLE
fix: search results missing link retarget, clear button center css

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Search/index.js
+++ b/packages/gatsby-theme-aio/src/components/Search/index.js
@@ -447,6 +447,17 @@ const Search = ({ algolia, indexAll, indexPrefix, showSearch, setShowSearch, sea
           }
         }
       }
+
+      if (searchResultsRef) {
+        if (searchResults.length > 0) {
+          const allLinks = searchResultsRef.current.querySelectorAll("a");
+          if (allLinks.length > 0) {
+            allLinks.forEach(link => {
+              link.target = "_top";
+            });
+          }
+        }
+      }
     }, [searchSuggestionResults, searchResults])
   }
 
@@ -530,6 +541,7 @@ const Search = ({ algolia, indexAll, indexPrefix, showSearch, setShowSearch, sea
                   position: absolute;
                   
                   margin-right: var(--spectrum-global-dimension-size-100);
+                  margin-bottom: var(--spectrum-global-dimension-size-40);
 
                   @media screen and (max-width: ${MOBILE_SCREEN_WIDTH}) {
                     margin-right: 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This fixes the bug where search frame's results links wouldn't target the top (parent) frame for links . Additionally minor css fix to center the clear input button.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
