### PR TITLE
NestedInlineAlert fix with margin top

### DIFF
--- a/packages/gatsby-theme-aio/src/components/InlineNestedAlert/index.js
+++ b/packages/gatsby-theme-aio/src/components/InlineNestedAlert/index.js
@@ -39,14 +39,14 @@ const InlineNestedAlertTexts = ({ texts }) => {
     alertElement.push(cloneElement(text, {
           className: 'spectrum-InLineAlert-content',
           css: css`
-                margin-top: var(--spectrum-global-dimension-size-150);
+                margin-top: 0;
                 ${commonCss};
               `
         }));
   }) : alertElement.push(cloneElement(texts, {
     className: 'spectrum-InLineAlert-content',
     css: css`
-                margin-top: var(--spectrum-global-dimension-size-150);
+                margin-top: 0;
                 ${commonCss};
               `
   }));
@@ -64,9 +64,10 @@ const InlineNestedAlert = ({ variant = 'info', header, iconPosition, ...props })
   }
   const alertCss = iconPosition === 'left' ? css`width: 98%;
             padding-left: 40px;
-            margin-top: var(--spectrum-global-dimension-size-300);
+            margin-top: 0;
             svg {
                 left: 0;
+                margin-top: 3px;
                 margin-left: var(--spectrum-global-dimension-size-175) !important;
             }` : css`min-width: 100%; margin-top: var(--spectrum-global-dimension-size-300)`;
   return (


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Nested Inline alert icon and margin top is not aligned. 

## Description
Fix the css to align the icon and the text. 
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
<img width="882" alt="Screen Shot 2023-02-21 at 3 59 24 PM" src="https://user-images.githubusercontent.com/14320591/220486012-1f4c2a14-42d8-4310-9be2-d6134714817a.png">

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
