### PR TITLE
Fix: add skip for records exceeding our algolia limit

### DIFF
--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -95,7 +95,12 @@ function indexRecords() {
           // Create Algolia records from rawRecords
           for (const rawRecord of rawRecords) {
             const record = await createAlgoliaRecord(rawRecord, markdownFile);
-            algoliaRecords.push(record);
+            if (record.size > 20000) {
+              console.warn(`Record at path ${record?.path} objectID=${record?.objectID} is too big
+              size=${record?.size}/20000 bytes and will be skipped.`);
+            } else {
+              algoliaRecords.push(record);
+            }
           }
         }
         // Return the normalized Algolia records to the plugin for indexing.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Algolia record size limit is 20000 bytes with our current plan and pushing a larger record will result in an error which will stop the indexing operation.

This PR adds a size check before adding record to final records list and logs a warning mentioning which records will be skipped.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/23483039/231029766-62e8e04c-114a-4a08-a481-1481abb66912.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
