### PR TITLE
fix: table not responding to parent size change

### DIFF
--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -70,7 +70,6 @@
     "@loadable/component": "^5.15.2",
     "@mdx-js/mdx": "1.6.22",
     "@mdx-js/react": "1.6.22",
-    "@react-hook/resize-observer": "^1.2.6",
     "@spectrum-css/accordion": "3.0.24",
     "@spectrum-css/actionbutton": "2.1.7",
     "@spectrum-css/actiongroup": "^2.0.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -65,10 +65,12 @@
     "@adobe/focus-ring-polyfill": "^0.1.5",
     "@adobe/gatsby-source-github-file-contributors": "^0.3.1",
     "@adobe/prism-adobe": "^1.0.3",
+    "@cutting/use-get-parent-size": "^2.1.2",
     "@emotion/react": "^11.10.4",
     "@loadable/component": "^5.15.2",
     "@mdx-js/mdx": "1.6.22",
     "@mdx-js/react": "1.6.22",
+    "@react-hook/resize-observer": "^1.2.6",
     "@spectrum-css/accordion": "3.0.24",
     "@spectrum-css/actionbutton": "2.1.7",
     "@spectrum-css/actiongroup": "^2.0.0",
@@ -138,6 +140,7 @@
     "redoc-cli": "^0.13.20",
     "rehype-slug-custom-id": "^1.1.0",
     "request": "^2.88.2",
+    "resize-observer-polyfill": "^1.5.1",
     "sharp": "^0.31.0",
     "stream-http": "^3.2.0",
     "styled-components": "^5.3.5",
@@ -145,6 +148,7 @@
     "to-arraybuffer": "^1.0.1",
     "tty-browserify": "^0.0.1",
     "unist-util-select": "3.0.4",
+    "use-debounce": "^9.0.4",
     "uuid": "^9.0.0"
   }
 }

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -65,7 +65,6 @@
     "@adobe/focus-ring-polyfill": "^0.1.5",
     "@adobe/gatsby-source-github-file-contributors": "^0.3.1",
     "@adobe/prism-adobe": "^1.0.3",
-    "@cutting/use-get-parent-size": "^2.1.2",
     "@emotion/react": "^11.10.4",
     "@loadable/component": "^5.15.2",
     "@mdx-js/mdx": "1.6.22",

--- a/packages/gatsby-theme-aio/src/components/Table/index.js
+++ b/packages/gatsby-theme-aio/src/components/Table/index.js
@@ -10,27 +10,32 @@
  * governing permissions and limitations under the License.
  */
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { css } from '@emotion/react';
 import PropTypes from 'prop-types';
 import '@spectrum-css/table';
-import { MOBILE_SCREEN_WIDTH } from '../../utils';
+import { MOBILE_SCREEN_WIDTH, useParentSize } from '../../utils';
 
 const Table = ({ children, css: cssOverrides, columnWidths, ...props }) => {
-  const [width, setWidth] = useState(MOBILE_SCREEN_WIDTH);
   const tableRef = useRef(null);
+  const [width, setWidth] = useState(parseInt(MOBILE_SCREEN_WIDTH, 10));
+
+  useParentSize(tableRef, {
+    debounceDelay: 500,
+    initialValues: { width: parseInt(MOBILE_SCREEN_WIDTH, 10) },
+    callback: size => {
+      if (size.width) {
+        setWidth(size.width);
+      }
+    },
+  });
+
   const columnWidthDistribution = columnWidths
     ? columnWidths
         .split(',')
         .map(num => (width * Number(num)) / 100)
         .filter(width => !isNaN(width))
     : [];
-
-  useEffect(() => {
-    if (tableRef.current.parentNode) {
-      setWidth(Number(tableRef.current.parentNode.offsetWidth));
-    }
-  }, [width]);
 
   return (
     <table

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,7 +40,6 @@ __metadata:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
     "@adobe/prism-adobe": ^1.0.3
-    "@cutting/use-get-parent-size": ^2.1.2
     "@emotion/react": ^11.10.4
     "@loadable/component": ^5.15.2
     "@mdx-js/mdx": 1.6.22
@@ -2014,22 +2013,6 @@ __metadata:
   dependencies:
     "@jridgewell/trace-mapping": 0.3.9
   checksum: 5718f267085ed8edb3e7ef210137241775e607ee18b77d95aa5bd7514f47f5019aa2d82d96b3bf342ef7aa890a346fa1044532ff7cc3009e7d24fce3ce6200fa
-  languageName: node
-  linkType: hard
-
-"@cutting/use-get-parent-size@npm:^2.1.2":
-  version: 2.1.2
-  resolution: "@cutting/use-get-parent-size@npm:2.1.2"
-  dependencies:
-    assert-ts: ^0.3.4
-    resize-observer-polyfill: ^1.5.1
-    use-debounce: ^9.0.4
-  peerDependencies:
-    react: ">= 18.x.x"
-    react-dom: ">= 18.x.x"
-    resize-observer-polyfill: "*"
-    use-debounce: ">= 9.0.x"
-  checksum: a197bed7c1b47818069bdcb009f4ddd14cd89078c82eb70d342ae27f8b7419bd24ce1b344df17bc018882a6e897177f65c4ad8b42e25a3fdd5be023d85ce988e
   languageName: node
   linkType: hard
 
@@ -6394,13 +6377,6 @@ __metadata:
   version: 1.0.0
   resolution: "assert-plus@npm:1.0.0"
   checksum: 19b4340cb8f0e6a981c07225eacac0e9d52c2644c080198765d63398f0075f83bbc0c8e95474d54224e297555ad0d631c1dcd058adb1ddc2437b41a6b424ac64
-  languageName: node
-  linkType: hard
-
-"assert-ts@npm:^0.3.4":
-  version: 0.3.4
-  resolution: "assert-ts@npm:0.3.4"
-  checksum: 143d6dd83c3cbe71bc4927d734de22ef0a0052f3bde059eed78d5ca5b71428bc35a5c0437d3637cde17583babc46116e6076414a4f69e5735e32391adc5984e6
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,12 @@ __metadata:
     "@adobe/focus-ring-polyfill": ^0.1.5
     "@adobe/gatsby-source-github-file-contributors": ^0.3.1
     "@adobe/prism-adobe": ^1.0.3
+    "@cutting/use-get-parent-size": ^2.1.2
     "@emotion/react": ^11.10.4
     "@loadable/component": ^5.15.2
     "@mdx-js/mdx": 1.6.22
     "@mdx-js/react": 1.6.22
+    "@react-hook/resize-observer": ^1.2.6
     "@spectrum-css/accordion": 3.0.24
     "@spectrum-css/actionbutton": 2.1.7
     "@spectrum-css/actiongroup": ^2.0.0
@@ -118,6 +120,7 @@ __metadata:
     redoc-cli: ^0.13.20
     rehype-slug-custom-id: ^1.1.0
     request: ^2.88.2
+    resize-observer-polyfill: ^1.5.1
     sharp: ^0.31.0
     stream-http: ^3.2.0
     styled-components: ^5.3.5
@@ -125,6 +128,7 @@ __metadata:
     to-arraybuffer: ^1.0.1
     tty-browserify: ^0.0.1
     unist-util-select: 3.0.4
+    use-debounce: ^9.0.4
     uuid: ^9.0.0
   peerDependencies:
     gatsby: ^4.22.0
@@ -2014,6 +2018,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@cutting/use-get-parent-size@npm:^2.1.2":
+  version: 2.1.2
+  resolution: "@cutting/use-get-parent-size@npm:2.1.2"
+  dependencies:
+    assert-ts: ^0.3.4
+    resize-observer-polyfill: ^1.5.1
+    use-debounce: ^9.0.4
+  peerDependencies:
+    react: ">= 18.x.x"
+    react-dom: ">= 18.x.x"
+    resize-observer-polyfill: "*"
+    use-debounce: ">= 9.0.x"
+  checksum: a197bed7c1b47818069bdcb009f4ddd14cd89078c82eb70d342ae27f8b7419bd24ce1b344df17bc018882a6e897177f65c4ad8b42e25a3fdd5be023d85ce988e
+  languageName: node
+  linkType: hard
+
 "@cypress/request@npm:^2.88.10":
   version: 2.88.11
   resolution: "@cypress/request@npm:2.88.11"
@@ -3102,6 +3122,13 @@ __metadata:
     "@jridgewell/resolve-uri": 3.1.0
     "@jridgewell/sourcemap-codec": 1.4.14
   checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
+  languageName: node
+  linkType: hard
+
+"@juggle/resize-observer@npm:^3.3.1":
+  version: 3.4.0
+  resolution: "@juggle/resize-observer@npm:3.4.0"
+  checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
   languageName: node
   linkType: hard
 
@@ -4480,6 +4507,37 @@ __metadata:
     preact: ^10.4.0
     webpack: ^4.0.0 || ^5.0.0
   checksum: 49d2184856f7c3335d339b3cff52c85b9524c6b215c120f701bfc7053781adea8db8908f158a756a9234af09acedff101fd087f4adcda367b38ca6403a9e5442
+  languageName: node
+  linkType: hard
+
+"@react-hook/latest@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@react-hook/latest@npm:1.0.3"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 2408c9cd35c5cfa7697b6da3bc5eebef254a932ade70955074c474f23be7dd3e2f81bbba12edcc9208bd0f89c6ed366d6b11d4f6d7b1052877a0bac8f74afad4
+  languageName: node
+  linkType: hard
+
+"@react-hook/passive-layout-effect@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "@react-hook/passive-layout-effect@npm:1.2.1"
+  peerDependencies:
+    react: ">=16.8"
+  checksum: 217cb8aa90fb8e677672319a9a466d7752890cf4357c76df000b207696e9cc717cf2ee88080671cc9dae238a82f92093ab4f61ab2f6032d2a8db958fc7d99b5d
+  languageName: node
+  linkType: hard
+
+"@react-hook/resize-observer@npm:^1.2.6":
+  version: 1.2.6
+  resolution: "@react-hook/resize-observer@npm:1.2.6"
+  dependencies:
+    "@juggle/resize-observer": ^3.3.1
+    "@react-hook/latest": ^1.0.2
+    "@react-hook/passive-layout-effect": ^1.2.0
+  peerDependencies:
+    react: ">=16.8"
+  checksum: d2ff6c50e847514acad774f2a4010fb1e6782a231ae00c9507c1a98028b3a26399e35f094170918f11b1eeafc581d60da7641bc178d496abf00c56eee8a6b36b
   languageName: node
   linkType: hard
 
@@ -6375,6 +6433,13 @@ __metadata:
   version: 1.0.0
   resolution: "assert-plus@npm:1.0.0"
   checksum: 19b4340cb8f0e6a981c07225eacac0e9d52c2644c080198765d63398f0075f83bbc0c8e95474d54224e297555ad0d631c1dcd058adb1ddc2437b41a6b424ac64
+  languageName: node
+  linkType: hard
+
+"assert-ts@npm:^0.3.4":
+  version: 0.3.4
+  resolution: "assert-ts@npm:0.3.4"
+  checksum: 143d6dd83c3cbe71bc4927d734de22ef0a0052f3bde059eed78d5ca5b71428bc35a5c0437d3637cde17583babc46116e6076414a4f69e5735e32391adc5984e6
   languageName: node
   linkType: hard
 
@@ -20737,6 +20802,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"resize-observer-polyfill@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "resize-observer-polyfill@npm:1.5.1"
+  checksum: 57e7f79489867b00ba43c9c051524a5c8f162a61d5547e99333549afc23e15c44fd43f2f318ea0261ea98c0eb3158cca261e6f48d66e1ed1cd1f340a43977094
+  languageName: node
+  linkType: hard
+
 "resolve-alpn@npm:^1.0.0":
   version: 1.2.1
   resolution: "resolve-alpn@npm:1.2.1"
@@ -23806,6 +23878,15 @@ __metadata:
     punycode: 1.3.2
     querystring: 0.2.0
   checksum: 50d100d3dd2d98b9fe3ada48cadb0b08aa6be6d3ac64112b867b56b19be4bfcba03c2a9a0d7922bfd7ac17d4834e88537749fe182430dfd9b68e520175900d90
+  languageName: node
+  linkType: hard
+
+"use-debounce@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "use-debounce@npm:9.0.4"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 37da4ecbe4e10a6230580cac03a8cae1788ea3e417dfdd92fcf654325458cf1b4567fd57bebf888edab62701a6abe47059a585008fd04228784f223f94d66ce4
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -45,7 +45,6 @@ __metadata:
     "@loadable/component": ^5.15.2
     "@mdx-js/mdx": 1.6.22
     "@mdx-js/react": 1.6.22
-    "@react-hook/resize-observer": ^1.2.6
     "@spectrum-css/accordion": 3.0.24
     "@spectrum-css/actionbutton": 2.1.7
     "@spectrum-css/actiongroup": ^2.0.0
@@ -3125,13 +3124,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@juggle/resize-observer@npm:^3.3.1":
-  version: 3.4.0
-  resolution: "@juggle/resize-observer@npm:3.4.0"
-  checksum: 2505028c05cc2e17639fcad06218b1c4b60f932a4ebb4b41ab546ef8c157031ae377e3f560903801f6d01706dbefd4943b6c4704bf19ed86dfa1c62f1473a570
-  languageName: node
-  linkType: hard
-
 "@lerna/child-process@npm:6.6.1":
   version: 6.6.1
   resolution: "@lerna/child-process@npm:6.6.1"
@@ -4507,37 +4499,6 @@ __metadata:
     preact: ^10.4.0
     webpack: ^4.0.0 || ^5.0.0
   checksum: 49d2184856f7c3335d339b3cff52c85b9524c6b215c120f701bfc7053781adea8db8908f158a756a9234af09acedff101fd087f4adcda367b38ca6403a9e5442
-  languageName: node
-  linkType: hard
-
-"@react-hook/latest@npm:^1.0.2":
-  version: 1.0.3
-  resolution: "@react-hook/latest@npm:1.0.3"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 2408c9cd35c5cfa7697b6da3bc5eebef254a932ade70955074c474f23be7dd3e2f81bbba12edcc9208bd0f89c6ed366d6b11d4f6d7b1052877a0bac8f74afad4
-  languageName: node
-  linkType: hard
-
-"@react-hook/passive-layout-effect@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "@react-hook/passive-layout-effect@npm:1.2.1"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 217cb8aa90fb8e677672319a9a466d7752890cf4357c76df000b207696e9cc717cf2ee88080671cc9dae238a82f92093ab4f61ab2f6032d2a8db958fc7d99b5d
-  languageName: node
-  linkType: hard
-
-"@react-hook/resize-observer@npm:^1.2.6":
-  version: 1.2.6
-  resolution: "@react-hook/resize-observer@npm:1.2.6"
-  dependencies:
-    "@juggle/resize-observer": ^3.3.1
-    "@react-hook/latest": ^1.0.2
-    "@react-hook/passive-layout-effect": ^1.2.0
-  peerDependencies:
-    react: ">=16.8"
-  checksum: d2ff6c50e847514acad774f2a4010fb1e6782a231ae00c9507c1a98028b3a26399e35f094170918f11b1eeafc581d60da7641bc178d496abf00c56eee8a6b36b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Table will now assign the same width as our main content column (`MOBILE_SCREEN_WIDTH`) by default and immediately starts observing the parent element for size changes using `useParentSize` util. If the parent element width is not 0 it will resize the Table to match.

I added `useParentSize` which is based on this [package's](https://github.com/dagda1/cuttingedge/blob/main/packages/use-get-parent-size/src/useParentSize/useParentSize.ts) code but stripped down from TS and modified to actually grab the parent elements size from the Table ref.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

DEVSITE-755

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Table wasn't resizing correctly when nested in a parent element with fickle width size.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested in the example and aep-mobile-sdk pages with tables.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
