### PR TITLE
fix(Table): Fix TBody children mapping

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Table/index.js
+++ b/packages/gatsby-theme-aio/src/components/Table/index.js
@@ -75,22 +75,22 @@ const THead = ({ children, ...props }) => {
 
 const Th = ({ children }) => <th className="spectrum-Table-headCell">{children}</th>;
 
-const TBody = ({ children, ...props }) => {
-  const childrenArr = children.length > 1 ? children : [children];
-  return (
-    <tbody
-      className="spectrum-Table-body"
-      css={css`
-        width: ${props.tableWidth}px;
-      `}>
-      {childrenArr.map(child => {
-        child.props.tableWidth = props.tableWidth;
-        child.props.columnWidthDistribution = props.columnWidthDistribution;
-        return child;
-      })}
-    </tbody>
-  );
-};
+const TBody = ({ children, ...props }) => (
+  <tbody
+    className="spectrum-Table-body"
+    css={css`
+      width: ${props.tableWidth}px;
+    `}>
+    {React.Children.map(children, child => ({
+      ...child,
+      props: {
+        ...child.props,
+        tableWidth: props.tableWidth,
+        columnWidthDistribution: props.columnWidthDistribution,
+      },
+    }))}
+  </tbody>
+);
 
 const Tr = ({ children, ...props }) => {
   const tableWidth = props.tableWidth;


### PR DESCRIPTION
## Description

Table `TBody` component errors when `children` is a single item array. For example, when using `array.map` to return `Tr` inside `TBody`.

## Related Issue
#1518 

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
