### PR TITLE
fix: check for isArray instead

### DIFF
--- a/packages/gatsby-theme-aio/src/components/Table/index.js
+++ b/packages/gatsby-theme-aio/src/components/Table/index.js
@@ -76,7 +76,7 @@ const THead = ({ children, ...props }) => {
 const Th = ({ children }) => <th className="spectrum-Table-headCell">{children}</th>;
 
 const TBody = ({ children, ...props }) => {
-  const childrenArr = children.length > 1 ? children : [children];
+  const childrenArr = Array.isArray(children) ? children : [children];
   return (
     <tbody
       className="spectrum-Table-body"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

When only one child (`{ }`) is passed to `children` prop it can be either `{ }` or `[{ }]` depending on how it was passed.
This is done for performance and consistent type reasons between rerenders. Changing the length check to isArray check to include this edge case.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
