### PR TITLE
feat: improved the report format and custom logs when isDryRun

### DIFF
--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -19,7 +19,7 @@ const parseHtml = require('./helpers/parse-html');
 const parseMdx = require('./helpers/parse-mdx');
 const createAlgoliaRecord = require('./create-record');
 
-function indexRecords() {
+function indexRecords(isDryRun) {
   return [
     {
       query: mdxQuery,
@@ -76,25 +76,48 @@ function indexRecords() {
           });
         }
 
-        // markdownFiles frontmatter report - start
+        const frontmatterReport = isDryRun => {
+          // markdownFiles frontmatter report - start
+          let warnCount = 0;
+          let passCount = 0;
 
-        console.log('\x1b[35m ==== FRONTMATTER REPORT - STARTING ==================== \x1b[0m');
-        console.info('\x1b[36m [cmd + click] on the file path to open \x1b[0m');
+          console.log('\x1b[35m ==== FRONTMATTER REPORT - STARTING ==================== \x1b[0m');
+          console.info('\x1b[36m [cmd + click] on the file path to open \x1b[0m');
+          markdownFiles.forEach(file => {
+            if (!file.description || !file.keywords || !file.title) {
+              warnCount++;
+              console.log('\n\x1b[43mWarn\x1b[0m - ' + file.fileAbsolutePath + ': ');
+              if (!file.title) console.log('\x1b[33m\tMissing Title \x1b[0m');
+              if (!file.description) console.log('\x1b[33m\tMissing Description \x1b[0m');
+              if (!file.keywords) console.log('\x1b[33m\tMissing Keywords \x1b[0m');
+            } else {
+              passCount++;
+              console.log('\x1b[42mPass\x1b[0m - ' + file.fileAbsolutePath);
+            }
+          });
 
-        markdownFiles.forEach(file => {
-          if (!file.description || !file.keywords || !file.title) {
-            console.log('\n\x1b[41mFail\x1b[0m - ' + file.fileAbsolutePath + ': ');
-            if (!file.title) console.log('\x1b[33m\tMissing Title \x1b[0m');
-            if (!file.description) console.log('\x1b[33m\tMissing Description \x1b[0m');
-            if (!file.keywords) console.log('\x1b[33m\tMissing Keywords \x1b[0m');
+          if (isDryRun) {
+            if (passCount)
+              console.info(
+                `- \x1b[42m${passCount} Pages have Title, Description, and Keywords\x1b[0m`
+              );
+            if (warnCount)
+              console.warn(`- \x1b[43m${warnCount} Pages are missing frontmatter\x1b[0m`);
           } else {
-            console.log('\x1b[42mPass\x1b[0m - ' + file.fileAbsolutePath);
+            if (passCount)
+              console.info(
+                `- \x1b[42m${passCount} Pages have Title, Description, and Keywords\x1b[0m`
+              );
+              // Implement an Error or prompt to user when attempting to index frontmatter-less files
+            if (warnCount)
+              console.error(`\x1b[41m${warnCount} Pages are missing frontmatter\x1b[0m`);
           }
-        });
+          console.log('\x1b[35m ==== FRONTMATTER REPORT - FINISHED ==================== \x1b[0m');
 
-        console.log('\x1b[35m ==== FRONTMATTER REPORT - FINISHED ==================== \x1b[0m');
+          // markdownFiles frontmatter report - end
+        };
 
-        // markdownFiles frontmatter report - end
+        frontmatterReport(isDryRun);
 
         const algoliaRecords = [];
 

--- a/packages/gatsby-theme-aio/gatsby-config.js
+++ b/packages/gatsby-theme-aio/gatsby-config.js
@@ -135,7 +135,7 @@ module.exports = {
         appId: process.env.GATSBY_ALGOLIA_APPLICATION_ID,
         indexName: process.env.GATSBY_ALGOLIA_INDEX_ENV_PREFIX ? `${process.env.GATSBY_ALGOLIA_INDEX_ENV_PREFIX}-${process.env.GATSBY_ALGOLIA_INDEX_NAME}` : process.env.GATSBY_ALGOLIA_INDEX_NAME,
         apiKey: process.env.ALGOLIA_WRITE_API_KEY,
-        queries: indexRecords(),
+        queries: indexRecords(isDryRun),
         chunkSize: 1000,
         algoliasearchOptions: {
           timeouts: {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

MOdified formatting to log warnings instead of fails per page with a final total displayed as a warn or error based on if it's a dry run or not. i.e console or index mode.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
index mode:
<img width="1323" alt="image" src="https://github.com/adobe/aio-theme/assets/23483039/b9f1ca66-1b34-49ff-b275-35cfe1a57c91">
console mode:
<img width="1323" alt="image" src="https://github.com/adobe/aio-theme/assets/23483039/5043df53-474e-4639-a8f2-93f4dfc45bff">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
