### PR TITLE
Ignore md pages when indexing if noIndex keyword set true

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,12 @@ For example, adding the `contributor_name` and `contributor_link` keywords to th
 
 ![attribution frontmatter keyword](docs/images/attribution_keyword_screenshot.png)
 
+#### Hide page from search with noIndex
+
+Adding `noIndex: true` will flag the page to be skipped during local search indexing. This is required when storing transcluded files under `src/pages/` since we index all pages by default.
+
+Note: duplicate results in local search are likely due to not setting `noIndex: true` inside transcluded pages.
+
 ### Markdown pages
 
 Make sure the markdown content is located under `src/pages`.

--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -25,7 +25,7 @@ function indexRecords(isDryRun) {
       query: mdxQuery,
       transformer: async function ({
         data: {
-          site: { pathPrefix },
+          site: { pathPrefix, noIndexList },
           github: { repository },
           allFile: { nodes },
         },
@@ -49,6 +49,10 @@ function indexRecords(isDryRun) {
 
         const markdownFiles = [];
         for (const node of nodes) {
+
+          // skip file if noIndex is set true in frontmatter
+          if (node.childMdx.frontmatter.noIndex) continue;
+
           markdownFiles.push({
             birthTime: node.birthTime,
             category: node.childMdx.frontmatter.category,
@@ -108,7 +112,7 @@ function indexRecords(isDryRun) {
               console.info(
                 `- \x1b[42m${passCount} Pages have Title, Description, and Keywords\x1b[0m`
               );
-              // Implement an Error or prompt to user when attempting to index frontmatter-less files
+            // Implement an Error or prompt to user when attempting to index frontmatter-less files
             if (warnCount)
               console.error(`\x1b[41m${warnCount} Pages are missing frontmatter\x1b[0m`);
           }

--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -25,7 +25,7 @@ function indexRecords(isDryRun) {
       query: mdxQuery,
       transformer: async function ({
         data: {
-          site: { pathPrefix, noIndexList },
+          site: { pathPrefix },
           github: { repository },
           allFile: { nodes },
         },

--- a/packages/gatsby-theme-aio/algolia/mdx-query.js
+++ b/packages/gatsby-theme-aio/algolia/mdx-query.js
@@ -50,6 +50,7 @@ const mdxQuery = `
           hideBreadcrumbNav
           contributor_name
           contributor_link
+          noIndex
         }
         headings {
           value

--- a/packages/gatsby-theme-aio/gatsby-node.js
+++ b/packages/gatsby-theme-aio/gatsby-node.js
@@ -184,7 +184,7 @@ exports.createResolvers = ({ createResolvers }) => {
       },
       contributors: {
         type: '[String]',
-        resolve: source => source.contributors
+        resolve: source => source.contributors,
       },
       contributor_link: {
         type: 'String',
@@ -225,6 +225,10 @@ exports.createResolvers = ({ createResolvers }) => {
       featured: {
         type: 'Boolean',
         resolve: source => source.featured || false,
+      },
+      noIndex: {
+        type: 'Boolean',
+        resolve: source => source.noIndex || false,
       },
     },
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Added support for flagging a page as noIndex.
Search index operation will ignore pages with `noIndex: true` in frontmatter.
This is a simple feature but important for repos with transcluded pages under `src/pages/` where we index all md pages by default. Currently such repos show duplicate results for the transcluded content in local search. The noIndex flag will help with removing these duplicates. 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
