### PR TITLE
4.11.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ Using a theme, all of your default configuration lives in an npm package.
     - [Metadata with Front matter](#metadata-with-front-matter)
     - [OpenAPI](#openapi)
     - [Redocly API Block](#RedoclyAPIBlock)
+      - [On-premise license keys](#on-premise-license-keys)
+      - [Full width page](#full-width-page)
+      - [width (optional)](#width-optional)
+      - [typography (optional)](#typography-optional)
+      - [codeblock (optional)](#codeblock-optional)
+      - [disableSidebar (optional)](#disablesidebar-optional)
+      - [disableSearch (optional)](#disablesearch-optional)
     - [JSDoc](#jsdoc)
     - [MDX](#mdx)
     - [Modular Content System](#modular-content-system)
@@ -1081,13 +1088,79 @@ We use [Redoc](https://github.com/Redocly/redoc) to render OpenAPI specs. Simply
 ```js
 <RedoclyAPIBlock src="URL pointing to your open api yaml file." />
 ```
+
 We can now host your own OpenAPI YAML files and have them rendered by Redocly documents. This approach allows us to avoid using iframes and instead host our own API YAML files directly in Redocly.
+
+#### On-premise license keys
 
 When implementing this feature, ensure that GATSBY_REDOCLY_KEY: ${{ secrets.REDOCLY_LICENSE_KEY }} is added to the deploy.yml file in the repository. Additionally, for new repositories, remember to include the on-premise license keys through the repository settings.
 
 The license key should be found in your redocly account settings -> On-premise license keys
 
 ![redocly-setting](docs/images/redocly-setting.png)
+
+#### Full width page 
+
+Use [custom layout](#custom-layout) to do a full width page
+
+#### width (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." width="600px" />
+```
+Sets the width (of the right panel). 
+
+Defaults to ```'500px'```
+
+https://redocly.com/docs/api-reference-docs/configuration/theming/#path=rightPanel
+
+#### typography (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." typography="fontFamily: `serif`, fontSize: '16px'" />
+```
+
+Controls the appearance of text. 
+
+Defaults to ```'fontFamily: `adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif`'```
+
+https://redocly.com/docs/api-reference-docs/configuration/theming/#path=typography
+
+#### codeblock (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." codeBlock="tokens: { punctuation: { color: 'red ' }}" />
+```
+
+Controls the appearance of code snippets. 
+
+Defaults to ```"tokens: { punctuation: { color: 'white' }}"```
+
+https://redocly.com/docs/api-reference-docs/configuration/theming/#path=codeBlock
+
+#### disableSidebar (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." disableSidebar />
+```
+
+If set to `true`, hides the navigation sidebar (the left panel). Setting this option to `false` does not disable the search feature. 
+
+Defaults to ```false```
+
+https://redocly.com/docs/api-reference-docs/configuration/functionality/#theme-object-openapi-schema
+
+#### disableSearch (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." disableSearch />
+```
+
+Disables search indexing and hides the search box from the API documentation page. 
+
+Defaults to ```false```
+
+https://redocly.com/docs/api-reference-docs/configuration/functionality/#theme-object-openapi-schema
 
 ### JSDoc
 

--- a/packages/gatsby-theme-aio/CHANGELOG.md
+++ b/packages/gatsby-theme-aio/CHANGELOG.md
@@ -3,6 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.11.7](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.11.4...@adobe/gatsby-theme-aio@4.11.7) (2024-03-13)
+
+### Features
+
+* **DEVSITE-1106:** Make width and codeblock customizable [8a76182](https://github.com/adobe/aio-theme/commit/8a76182c4f259331975e478d320a19d01a21bf3c)
+* **DEVSITE-1106:** Make disableSidebar and disableSearch customizable [486625c](https://github.com/adobe/aio-theme/commit/486625c98452b8a5f657840e366a701069e41e0d)
+* **DEVSITE-1106:** Make typography customizable [a5e783b](https://github.com/adobe/aio-theme/commit/a5e783bfd5e516de4eb2e2d6d7f26135a8a0e7c3)
+
+### Fix
+
+* **DEVSITE-1106:** Hide loading animation as a work-around to make the redocly integration appear more seamless [c3396c3](https://github.com/adobe/aio-theme/commit/c3396c308ff4a2623500aceba744eec47cef374c)
+
 ## [4.11.4](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.11.3...@adobe/gatsby-theme-aio@4.11.4) (2023-02-28)
 
 ### Fix

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc2",
+  "version": "4.11.5-rc3",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc5",
+  "version": "4.11.5-rc6",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.4",
+  "version": "4.11.5-rc1",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.7-rc2",
+  "version": "4.11.7-rc4",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc7",
+  "version": "4.11.5-rc8",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc8",
+  "version": "4.11.7-rc2",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.7-rc4",
+  "version": "4.11.7",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc1",
+  "version": "4.11.5-rc2",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc6",
+  "version": "4.11.5-rc7",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.11.5-rc3",
+  "version": "4.11.5-rc5",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -54,11 +54,9 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
             `RedoclyReferenceDocs.init(
                '${src}',
               {licenseKey: '${licenseKey}',
+               disableSidebar: true, 
+               disableSearch: true,
                theme: {
-                openapi: {
-                  disableSidebar: true,
-                  disableSearch: true,
-                },
                 rightPanel: {
                   width: '${width}',
                   },

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 const licenseKey = process.env.GATSBY_REDOCLY_KEY;
 
 // Redocly API Block that will render the OpenAPI yaml files with Redocly TryIt feature.
-const RedoclyAPIBlock = ({ src }) => {
+const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'red' }}" }) => {
   const [isRedoclyLoading, setIsRedoclyLoading] = useState(true);
 
   let input = {};
@@ -55,9 +55,14 @@ const RedoclyAPIBlock = ({ src }) => {
                '${src}',
               {licenseKey: '${licenseKey}',
                theme: {
+                openapi: {
+                  disableSidebar: true,
+                },
                 rightPanel: {
-                  width: '500px',
+                  width: '${width}',
                   },
+                  ${codeBlock ?
+              "codeBlock: { " + codeBlock + "}," : ''}
                 },
               },
               document.querySelector('#redocly_container'),

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -57,6 +57,7 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
                theme: {
                 openapi: {
                   disableSidebar: true,
+                  disableSearch: true,
                 },
                 rightPanel: {
                   width: '${width}',

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -18,7 +18,13 @@ import PropTypes from 'prop-types';
 const licenseKey = process.env.GATSBY_REDOCLY_KEY;
 
 // Redocly API Block that will render the OpenAPI yaml files with Redocly TryIt feature.
-const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'white' }}", disableSidebar = false, disableSearch = false }) => {
+const RedoclyAPIBlock = ({
+  src, width = '500px',
+  typography = 'fontFamily: `adobe-clean, "Source Sans Pro", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Trebuchet MS", "Lucida Grande", sans-serif`',
+  codeBlock = "tokens: { punctuation: { color: 'white' }}",
+  disableSidebar = false,
+  disableSearch = false
+}) => {
   const [isRedoclyLoading, setIsRedoclyLoading] = useState(true);
 
   let input = {};
@@ -58,11 +64,11 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
                disableSearch: ${disableSearch},
                hideLoading: true,
                theme: {
+                ${typography ? "typography: { " + typography + "}," : ''}
                 rightPanel: {
                   width: '${width}',
                   },
-                  ${codeBlock ?
-              "codeBlock: { " + codeBlock + "}," : ''}
+                  ${codeBlock ? "codeBlock: { " + codeBlock + "}," : ''}
                 },
               },
               document.querySelector('#redocly_container'),
@@ -77,6 +83,7 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
 RedoclyAPIBlock.propTypes = {
   src: PropTypes.string,
   width: PropTypes.string,
+  typography: PropTypes.string,
   codeBlock: PropTypes.string,
   disableSidebar: PropTypes.bool,
   disableSearch: PropTypes.bool,

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -56,6 +56,7 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
               {licenseKey: '${licenseKey}',
                disableSidebar: true, 
                disableSearch: true,
+               hideLoading: true,
                theme: {
                 rightPanel: {
                   width: '${width}',

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 const licenseKey = process.env.GATSBY_REDOCLY_KEY;
 
 // Redocly API Block that will render the OpenAPI yaml files with Redocly TryIt feature.
-const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'white' }}" }) => {
+const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'white' }}", disableSidebar = false, disableSearch = false }) => {
   const [isRedoclyLoading, setIsRedoclyLoading] = useState(true);
 
   let input = {};
@@ -48,14 +48,14 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
     <>
       {!isRedoclyLoading && (
         <>
-          <div id="redocly_container"/>
+          <div id="redocly_container" />
 
           <script>{
             `RedoclyReferenceDocs.init(
                '${src}',
               {licenseKey: '${licenseKey}',
-               disableSidebar: true, 
-               disableSearch: true,
+               disableSidebar: ${disableSidebar}, 
+               disableSearch: ${disableSearch},
                hideLoading: true,
                theme: {
                 rightPanel: {
@@ -75,7 +75,11 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
 };
 
 RedoclyAPIBlock.propTypes = {
-  src: PropTypes.string
+  src: PropTypes.string,
+  width: PropTypes.string,
+  codeBlock: PropTypes.string,
+  disableSidebar: PropTypes.bool,
+  disableSearch: PropTypes.bool,
 };
 
 export { RedoclyAPIBlock };

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 const licenseKey = process.env.GATSBY_REDOCLY_KEY;
 
 // Redocly API Block that will render the OpenAPI yaml files with Redocly TryIt feature.
-const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'red' }}" }) => {
+const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'white' }}" }, disableSidebar=false, disableSearch=false) => {
   const [isRedoclyLoading, setIsRedoclyLoading] = useState(true);
 
   let input = {};
@@ -54,8 +54,8 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
             `RedoclyReferenceDocs.init(
                '${src}',
               {licenseKey: '${licenseKey}',
-               disableSidebar: true, 
-               disableSearch: true,
+               disableSidebar: ${disableSidebar}, 
+               disableSearch: ${disableSearch},
                theme: {
                 rightPanel: {
                   width: '${width}',

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -18,7 +18,7 @@ import PropTypes from 'prop-types';
 const licenseKey = process.env.GATSBY_REDOCLY_KEY;
 
 // Redocly API Block that will render the OpenAPI yaml files with Redocly TryIt feature.
-const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'white' }}" }, disableSidebar=false, disableSearch=false) => {
+const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuation: { color: 'white' }}" }) => {
   const [isRedoclyLoading, setIsRedoclyLoading] = useState(true);
 
   let input = {};
@@ -54,8 +54,8 @@ const RedoclyAPIBlock = ({ src, width = '500px', codeBlock = "tokens: { punctuat
             `RedoclyReferenceDocs.init(
                '${src}',
               {licenseKey: '${licenseKey}',
-               disableSidebar: ${disableSidebar}, 
-               disableSearch: ${disableSearch},
+               disableSidebar: true, 
+               disableSearch: true,
                theme: {
                 rightPanel: {
                   width: '${width}',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Added optional parameters (i.e. width, typography, codeblock, disableSidebar, and disableSearch) to `RedoclyApiBlock`
- Hid loading animation as a work-around to make the redocly integration appear more seamless.

## Description
[DEVSITE-1106](https://jira.corp.adobe.com/browse/)

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
