### PR TITLE
Enable partial updates and fix algolia record size calculation

### DIFF
--- a/packages/gatsby-theme-aio/algolia/create-record.js
+++ b/packages/gatsby-theme-aio/algolia/create-record.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const { getAdobeDocType } = require("./helpers/get-adobe-doctype");
+const { getAdobeDocType } = require('./helpers/get-adobe-doctype');
 
 async function createRecord(rawRecord, file) {
   const record = {
@@ -30,7 +30,7 @@ async function createRecord(rawRecord, file) {
     objectID: rawRecord.objectID,
     path: getPath(rawRecord, file),
     product: file.product,
-    size: file.size,
+    size: Buffer.byteLength(JSON.stringify(rawRecord), 'utf16'),
     slug: file.slug,
     title: rawRecord.title,
     url: getUrl(rawRecord, file),
@@ -62,13 +62,13 @@ function getKeywords(keywords) {
 
 // Full url complete with anchor link to the nearest heading for the search record result.
 function getUrl(rawRecord, file) {
-  return `${process.env.GATSBY_SITE_DOMAIN_URL}${file.pathPrefix}${file.slug == null ? '' : file.slug
-    }${rawRecord.anchor}`;
+  return `${process.env.GATSBY_SITE_DOMAIN_URL}${file.pathPrefix}${
+    file.slug == null ? '' : file.slug
+  }${rawRecord.anchor}`;
 }
 
 function getPath(rawRecord, file) {
-  return `${file.pathPrefix}${file.slug == null ? '' : file.slug
-  }${rawRecord.anchor}`;
+  return `${file.pathPrefix}${file.slug == null ? '' : file.slug}${rawRecord.anchor}`;
 }
 
 module.exports = createRecord;

--- a/packages/gatsby-theme-aio/algolia/helpers/html-parser.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/html-parser.js
@@ -3,6 +3,7 @@
 
 const { JSDOM } = require('jsdom');
 const uuid = require('uuid');
+const { createContentDigest } = require("gatsby-core-utils");
 
 // Extract content from an HTML page in the form of items with associated headings data
 module.exports = class HtmlParser {
@@ -93,7 +94,7 @@ module.exports = class HtmlParser {
       };
 
       item.objectID = uuid.v4(item);
-      item.contentDigest = uuid.v4(content);
+      item.contentDigest = createContentDigest(content);
       item.words = content.split(' ').length;
       item.title = Object.values(currentHierarchy).filter(h => h)[0];
       item.contentHeading = Object.values(currentHierarchy).filter(h => h)[1];

--- a/packages/gatsby-theme-aio/algolia/helpers/parse-mdx.js
+++ b/packages/gatsby-theme-aio/algolia/helpers/parse-mdx.js
@@ -36,7 +36,7 @@ function parseMdx(markdownFile) {
 
     const rawRecord = {
       objectID: uuid.v4(nodeValue),
-      contentDigest: uuid.v4(nodeValue),
+      contentDigest: markdownFile.contentDigest,
       content: nodeValue,
       headings: markdownFile.headings.map(heading => heading.value),
       contentHeading: getContentHeading(mdastNode, markdownFile),

--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -72,7 +72,7 @@ function indexRecords(isDryRun) {
             objectID: node.id,
             openAPISpec: node.childMdx.frontmatter.openAPISpec,
             pathPrefix: `${pathPrefix}/`,
-            product: productFromPath.productName,
+            product: productFromPath.productName ? productFromPath.productName : "other",
             size: node.size,
             slug: node.childMdx.slug,
             title: node.childMdx.frontmatter.title,
@@ -145,6 +145,7 @@ function indexRecords(isDryRun) {
           for (const rawRecord of rawRecords) {
             const record = await createAlgoliaRecord(rawRecord, markdownFile);
             if (record.size > 20000) {
+              console.warn(JSON.stringify(record));
               console.warn(`Record at path ${record?.path} objectID=${record?.objectID} is too big
               size=${record?.size}/20000 bytes and will be skipped.`);
             } else {

--- a/packages/gatsby-theme-aio/algolia/index-records.js
+++ b/packages/gatsby-theme-aio/algolia/index-records.js
@@ -64,6 +64,7 @@ function indexRecords(isDryRun) {
             frameSrc: node.childMdx.frontmatter.frameSrc,
             headings: node.childMdx.headings,
             howRecent: node.howRecent,
+            contentDigest: node.internal.contentDigest,
             icon: node.icon,
             isNew: node.isNew,
             keywords: node.childMdx.frontmatter.keywords,

--- a/packages/gatsby-theme-aio/gatsby-config.js
+++ b/packages/gatsby-theme-aio/gatsby-config.js
@@ -135,6 +135,8 @@ module.exports = {
       options: {
         appId: process.env.GATSBY_ALGOLIA_APPLICATION_ID,
         indexName: process.env.GATSBY_ALGOLIA_INDEX_ENV_PREFIX ? `${process.env.GATSBY_ALGOLIA_INDEX_ENV_PREFIX}-${process.env.GATSBY_ALGOLIA_INDEX_NAME}` : process.env.GATSBY_ALGOLIA_INDEX_NAME,
+        // Use Admin API key without GATSBY_ prefix, so that the key isn't exposed in the application
+        // Tip: use Search API key with GATSBY_ prefix to access the service from within components
         apiKey: process.env.ALGOLIA_WRITE_API_KEY,
         queries: indexRecords(isDryRun),
         chunkSize: 1000,
@@ -147,7 +149,7 @@ module.exports = {
         },
         settings: indexSettings(),
         mergeSettings: false,
-        enablePartialUpdates: false,
+        enablePartialUpdates: true,
         matchFields: ['contentDigest'],
         concurrentQueries: false, // default: true
         dryRun: isDryRun, // default: true. When false, a new index is pushed to Algolia.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fix for record size calculation. Previously skipped indexing because size was larger than algolia's limit for records.
- Enabled partial updates in gatsby-plugin-algolia and configured contentDigest in html parser and mdx query for diff checking.

Note:

- Current uuid object ids make it difficult to match records and need to be redesigned for more partial update support. Will follow up with another PR.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
