### PR TITLE
fix: IOC-7708 - redirect user to the signin page if API call returns 401

### DIFF
--- a/packages/gatsby-theme-aio/src/components/GetCredential/Service.js
+++ b/packages/gatsby-theme-aio/src/components/GetCredential/Service.js
@@ -14,6 +14,9 @@ export const getOrganizations = async () => {
       });
 
       if (!response.ok) {
+        if (response.status === 401) {
+          window.adobeIMS?.signIn();
+        }
         throw new Error('Could not fetch accounts');
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
If a user is working on the devsite and using the get credentials component and they logout from their account or switch to another account **in a different tab** (for example, by going to dev console), the get credential component starts throwing unknown error. I have fixed this by redirecting the user to the SUSI page if the API returns 401.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://jira.corp.adobe.com/browse/IOC-7708
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
