### PR TITLE
fix: maximize columns in discover block

### DIFF
--- a/packages/gatsby-theme-aio/CHANGELOG.md
+++ b/packages/gatsby-theme-aio/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.14.7](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.6..@adobe/gatsby-theme-aio@4.14.7) (2024-07-30)
+
+### Fix
+* **DEVSITE-1154:** Maximize columns in discover block [053003f](https://github.com/adobe/aio-theme/pull/1608/commits/053003f0970ce48c0e7fdd3578465ab27f0bfefe)
+
+
 ## [4.14.6](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.13.5..@adobe/gatsby-theme-aio@4.14.6) (2024-07-25)
 
 ### Fix

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.14.6",
+  "version": "4.14.7",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/src/components/MDXFilter/index.js
+++ b/packages/gatsby-theme-aio/src/components/MDXFilter/index.js
@@ -226,12 +226,17 @@ export default ({ children, pageContext, query }) => {
 
     const columns = 12;
     const diff = [];
-    if (hasOnThisPage) {
-      diff.push(`${layoutColumns(2)} - var(--spectrum-global-dimension-size-400)`);
+
+    let asideCount = 0;
+    if (hasSideNav) ++asideCount;
+    if (hasOnThisPage) ++asideCount;
+    if (hasResources) ++asideCount;
+    
+    if(asideCount > 0) {
+      const layoutWidth = layoutColumns(asideCount + 1);
+      diff.push(`${layoutWidth} - var(--spectrum-global-dimension-size-400)`);
     }
-    if (hasResources) {
-      diff.push(`${layoutColumns(3)} - var(--spectrum-global-dimension-size-400)`);
-    }
+
     if (hasSideNav) {
       diff.push(SIDENAV_WIDTH);
     }


### PR DESCRIPTION
## Description

**Issue:** Even when there's room, Discover block limits itself two columns. For example

<img width="1728" alt="Screenshot 2024-07-30 at 7 30 19 PM" src="https://github.com/user-attachments/assets/b1d7e27c-200a-462d-a8d9-99b78d9dba10">

**Root-cause:** https://github.com/adobe/aio-theme/pull/1571

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1154
https://jira.corp.adobe.com/browse/DEVSITE-1116

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

2-columns when page has side-nav:

- <img width="1728" alt="Screenshot 2024-07-30 at 8 02 59 PM" src="https://github.com/user-attachments/assets/298ea04c-b594-40c3-8a98-69d962816150">



3-columns when page has no side-nav:

- <img width="1728" alt="Screenshot 2024-07-30 at 8 02 41 PM" src="https://github.com/user-attachments/assets/4f26afa4-2048-424e-8659-d8f3ddf758e3">


Confirming no regressions on https://github.com/adobe/aio-theme/pull/1571 - i.e. hero is still aligned with overview + resources




- ![firefly](https://github.com/user-attachments/assets/adf826e3-983d-4310-84a6-3265a9492657)

- ![commerce](https://github.com/user-attachments/assets/c3fee3d4-774e-4ee0-9265-712b7fa64699)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
