### PR TITLE
feat: sticky feedback component

### DIFF
--- a/packages/gatsby-theme-aio/CHANGELOG.md
+++ b/packages/gatsby-theme-aio/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.14.9](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.8..@adobe/gatsby-theme-aio@4.14.9) (2024-08-09)
+
+### Features
+* **DEVSITE-1070:** Sticky feedback component [285a739](https://github.com/adobe/aio-theme/commit/285a7397f63c6218dc0a73bda93f753fe23af865)
+
 ## [4.14.8](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.7..@adobe/gatsby-theme-aio@4.14.8) (2024-08-07)
 
 ### Fix

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.14.8",
+  "version": "4.14.9",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/src/components/MDXFilter/index.js
+++ b/packages/gatsby-theme-aio/src/components/MDXFilter/index.js
@@ -379,6 +379,13 @@ export default ({ children, pageContext, query }) => {
                       align-items: center;
                       justify-content: space-between;
                       margin-bottom: var(--spectrum-global-dimension-size-200);
+                      position: sticky;
+                      bottom: 3px;
+                      background: white;
+                      border: 1px solid;
+                      border-color: lightgray;
+                      border-radius: 4px;
+                      padding: .75rem;
                     `}>
                     <div>
                       <Contributors


### PR DESCRIPTION
## Description

Make feedback component sticky by applying changes from https://github.com/AdobeDocs/commerce-webapi/pull/269 to aio-theme

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1070

## Motivation and Context

- User engagement increased significantly with sticky feedback component [in an experiment done by commerce team](https://jira.corp.adobe.com/browse/COMDOX-887)
- Devsite-team decided to make this the default design for the Feedback/MDXFilter component in the aio-theme:
<img width="1054" alt="Screenshot 2024-08-09 at 1 42 38 PM" src="https://github.com/user-attachments/assets/87e09f69-b102-43c7-8083-703b502ba582">


## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

Desktop:
<img width="1470" alt="Screenshot 2024-08-09 at 1 26 19 PM" src="https://github.com/user-attachments/assets/eb3af109-6082-4f18-bad5-d14191a28d77">

Mobile:

<img width="500" alt="Screenshot 2024-08-09 at 1 38 26 PM" src="https://github.com/user-attachments/assets/78594621-f318-489d-a044-ba3b1ac38222">


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
