### PR TITLE
fix: readme for request interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,12 +1252,12 @@ https://redocly.com/docs/api-reference-docs/configuration/functionality#theme-ob
 ```js
 <RedoclyAPIBlock 
     src="/redocly-test/openapi/openapi.yaml"
-    requestInterceptor=
-        "(req, operation) => ({ 
-            console.log('Args:', req, rawOperation);
+    requestInterceptor="
+        function(req, operation) { 
+            console.log('Args:', req, operation); 
             return req; 
-        })"
-/>
+        }
+    " 
 ```
 
 Configures the request interceptor for the Try it console. As a prerequisite, the Try it console must be enabled in Reference docs (hideTryItPanel must be set to false). When configured, the interceptor can capture the request object and modify it according to specified criteria. Async usage is supported.


### PR DESCRIPTION
## Description

Fix example in readme for request interceptor

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1190

## Motivation and Context

Initially used the same syntax used as the [redocly example](https://redocly.com/docs/api-reference-docs/configuration/functionality#example-configuration-with-javascript-library) (see hooks BeforeOperationSummary), but that resulted in syntax error (because of the way we're passing the function as a string argument to RedoclyAPIBlock):
```
  api-full/:11 Uncaught SyntaxError: Unexpected token '.'
      at w (preact.module.js:159:106)
      at x (preact.module.js:136:781)
      at L (preact.module.js:278:174)
      at x (preact.module.js:136:215)
      at L (preact.module.js:278:174)
      at N (preact.module.js:110:156)
```

Updating the readme with what works: https://github.com/adobe/aio-theme/pull/1588/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R1229-R1233

## How Has This Been Tested?



## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
