### PR TITLE
feat: redocly scroll y offset

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Using a theme, all of your default configuration lives in an npm package.
       - [disableSidebar (optional)](#disablesidebar-optional)
       - [disableSearch (optional)](#disablesearch-optional)
       - [hideTryItPanel (optional)](#hidetryitpanel-optional)
+      - [scrollYOffset (optional)](#scrollyoffset-optional)
       - [sortOperationsAlphabetically (optional)](#sortoperationsalphabetically-optional)
       - [sortTagsAlphabetically (optional)](#sorttagsalphabetically-optional)
       - [jsonSampleExpandLevel (optional)](#jsonsampleexpandlevel-optional)
@@ -1198,6 +1199,19 @@ Disables the Try it console in the right panel.
 Defaults to ```false```
 
 https://redocly.com/docs/api-reference-docs/configuration/functionality/#theme-object-openapi-schema
+
+#### scrollYOffset (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." scrollYOffset={64} />
+```
+
+Specifies a vertical scroll-offset. This is useful when there are fixed positioned elements at the top of the page, such as navbars, headers etc. You can specify the scrollYOffset value as a number - a fixed number of pixels to be used as the offset.
+
+Defaults to ```0```
+
+https://redocly.com/docs/api-reference-docs/configuration/functionality/#theme-object-openapi-schema
+
 
 #### sortOperationsAlphabetically (optional)
 

--- a/packages/gatsby-theme-aio/CHANGELOG.md
+++ b/packages/gatsby-theme-aio/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.14.11](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.10..@adobe/gatsby-theme-aio@4.14.11) (2024-09-24)
+
+### Features
+* Add scrollYOffset config to RedoclyAPIBlock [1d2746c](https://github.com/adobe/aio-theme/commit/1d2746c2bc74d5055ec3cdc425fd635bd7bc94ab)
+
 ## [4.14.10](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.9..@adobe/gatsby-theme-aio@4.14.10) (2024-08-14)
 
 ### Features

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.14.10",
+  "version": "4.14.11",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -26,6 +26,7 @@ const RedoclyAPIBlock = ({
   disableSidebar = false,
   disableSearch = false,
   hideTryItPanel = false,
+  scrollYOffset = 0,
   sortOperationsAlphabetically = false,
   sortTagsAlphabetically = false,
   jsonSampleExpandLevel = 2,
@@ -70,6 +71,7 @@ const RedoclyAPIBlock = ({
                disableSidebar: ${disableSidebar}, 
                disableSearch: ${disableSearch},
                hideTryItPanel: ${hideTryItPanel},
+               scrollYOffset: ${scrollYOffset},
                sortOperationsAlphabetically: ${sortOperationsAlphabetically},
                sortTagsAlphabetically: ${sortTagsAlphabetically},
                jsonSampleExpandLevel: ${jsonSampleExpandLevel === all ? `'${jsonSampleExpandLevel}'` : jsonSampleExpandLevel},
@@ -101,6 +103,7 @@ RedoclyAPIBlock.propTypes = {
   disableSidebar: PropTypes.bool,
   disableSearch: PropTypes.bool,
   hideTryItPanel: PropTypes.bool,
+  scrollYOffset: PropTypes.number,
   sortOperationsAlphabetically: PropTypes.bool,
   sortTagsAlphabetically: PropTypes.bool,
   jsonSampleExpandLevel: PropTypes.oneOfType([


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable scrollYOffset config so user can adjust the top of the redocly page so that it doesn't overlap with the top nav.

## Related Issue

https://jira.corp.adobe.com/browse/DEVSITE-1347
https://jira.corp.adobe.com/browse/DEVSITE-1308

## Motivation and Context

Slack conversation: https://adobeio.slack.com/archives/C01GU3V8XE0/p1727220077882769

This serves two purposes:

- provide a quick fix for https://jira.corp.adobe.com/browse/DEVSITE-1347, while we haven't migrated to the next gen yet (where we're using layout grid, which better addresses the issue)
- fulfill request in https://jira.corp.adobe.com/browse/DEVSITE-1308 to add more configs to RedoclyAPIBlock so to retain same look and feel when migrating from portal to on-premise-license version

## How Has This Been Tested?

Page: https://developer-stage.adobe.com/redocly-test/api-full/#operation/getInventory
Src: https://github.com/AdobeDocs/redocly-test/commit/29aa4d50c45aa71e6745fb44db232b6c9415f6d1#diff-ebd9ea94b0769347dd6343596cd0a667cbe2004d8c7a3cd952c4ae6d055f69d7R3

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
