### PR TITLE
chore(release): publish@4.14.14

### DIFF
--- a/packages/gatsby-theme-aio/CHANGELOG.md
+++ b/packages/gatsby-theme-aio/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.14.14](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.13..@adobe/gatsby-theme-aio@4.14.14) (2024-10-30)
+
+### Fix
+* Ignore lottie module during server-side rendering to avoid build error [efbc27b](https://github.com/adobe/aio-theme/commit/efbc27b7a6ca3f859dbde85ffe09cb2ffff53784)
+
 ## [4.14.13](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.14.12..@adobe/gatsby-theme-aio@4.14.13) (2024-10-10)
 
 ### Fix

--- a/packages/gatsby-theme-aio/gatsby-node.js
+++ b/packages/gatsby-theme-aio/gatsby-node.js
@@ -12,7 +12,7 @@
 
 const { ProvidePlugin } = require('webpack');
 
-exports.onCreateWebpackConfig = ({ actions }) => {
+exports.onCreateWebpackConfig = ({ stage, loaders, actions }) => {
   actions.setWebpackConfig({
     resolve: {
       fallback: {
@@ -31,6 +31,16 @@ exports.onCreateWebpackConfig = ({ actions }) => {
       }),
     ],
   });
+  if(stage === 'build-html'){
+    actions.setWebpackConfig({
+      module: {
+        rules: [{
+          test: /lottie/,
+          use: loaders.null()
+        }]
+      }
+    });
+  }
 };
 
 exports.createSchemaCustomization = ({ actions }) => {

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.14.13",
+  "version": "4.14.14",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Description

**Issue** 
A few repos are failing build with error "ReferenceError:document is not defined"
- create-embed-sdk: https://github.com/AdobeDocs/create-embed-sdk/actions/runs/11586131790/job/32281470877
- express-add-ons: https://github.com/AdobeDocs/express-add-ons/actions/runs/11589307950/job/32264563671
- ff-services-docs: https://github.com/AdobeDocs/ff-services-docs/actions/runs/11585209248/job/32253763987

<img width="1060" alt="Screenshot 2024-10-30 at 12 52 00 PM" src="https://github.com/user-attachments/assets/3c53acbb-632e-4643-9bb8-4c71a5903835">



**Fix** 
Ignore lottie during server-side rendering to avoid build error (similar to https://tonye.design/writing/window-document-not-defined-gatsby-build/)



**Test** 
- created an RC: https://github.com/adobe/aio-theme/blob/fix-lottie-build-failure/packages/gatsby-theme-aio/package.json#L3
- installed RC in a create-embed-sdk branch: https://github.com/AdobeDocs/create-embed-sdk/blob/fix-lottie-build-failure/package.json#L15
- deploy successful: https://github.com/AdobeDocs/create-embed-sdk/actions/runs/11600408715



**Slack** 
https://adobeio.slack.com/archives/GTSGK6807/p1730258918243399

