### PR TITLE
ci: test new ghars on ethos ccc in dev

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,7 +21,7 @@ jobs:
     container:
       image: cypress/browsers:node-20.14.0-chrome-126.0.6478.114-1-ff-127.0.1-edge-126.0.2592.61-1
       options: --user root
-    runs-on: self-hosted
+    runs-on: developer-website-arc-dev-runners-aat 
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
### Changes

- Test out using GitHub Action Runners on Ethos CCC via `developer-website-arc-dev-runners-aat` runner label in the `e2e-tests.yml` workflow

### Related Issues

- [IOXTD-3169](https://jira.corp.adobe.com/browse/IOXTD-3169)