### PR TITLE
fix: redoclyapiblock overflow

### DIFF
--- a/packages/gatsby-theme-aio/CHANGELOG.md
+++ b/packages/gatsby-theme-aio/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## [4.15.2](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.15.1..@adobe/gatsby-theme-aio@4.15.2) (2025-07-21)
+
+### Fix
+
+* Prevent RedoclyAPIBlock from overflowing [9554f4b](https://github.com/adobe/aio-theme/commit/9554f4b492fc0c5b01dd8350ceaaf0654057ccc1)
+
 ## [4.15.1](https://github.com/adobe/aio-theme/compare/@adobe/gatsby-theme-aio@4.15.0..@adobe/gatsby-theme-aio@4.15.1) (2025-05-21)
 
 ### Fix

--- a/packages/gatsby-theme-aio/package.json
+++ b/packages/gatsby-theme-aio/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/gatsby-theme-aio",
-  "version": "4.15.1",
+  "version": "4.15.2",
   "description": "The Adobe I/O theme for building markdown powered sites",
   "main": "index.js",
   "license": "Apache-2.0",

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -63,7 +63,7 @@ const RedoclyAPIBlock = ({
     <>
       {!isRedoclyLoading && (
         <>
-          <div id="redocly_container" />
+          <div id="redocly_container" style={{ maxWidth: "100vw" }} />
 
           <script>{
             `RedoclyReferenceDocs.init(


### PR DESCRIPTION
## Description
Prevent `RedoclyAPIBlock` from overflowing by setting `redocly_container` max width

## Related Issue
https://jira.corp.adobe.com/browse/DEVSITE-1810


## How Has This Been Tested?
Tested with [4.15.2-rc3](https://github.com/adobe/aio-theme/releases/tag/%40adobe%2Fgatsby-theme-aio%404.14.20-rc3) on [redocly-test](https://github.com/AdobeDocs/redocly-test/blob/main/src/pages/overflow/without-layout-with-sidebar.md?plain=1) to mirror [Radu's file](https://github.com/AdobeDocs/experience-manager-apis/blob/main/src/pages/api/stable/assets/author/index.md?plain=1).

**Before:**
https://developer.adobe.com/experience-cloud/experience-manager-apis/api/stable/assets/author/
<img width="1728" height="1039" alt="Screenshot 2025-07-18 at 2 35 02 PM" src="https://github.com/user-attachments/assets/19233846-0e68-482d-bc9b-c8ff0154b717" />

**After:**
https://developer-stage.adobe.com/redocly-test/overflow/without-layout-with-sidebar/
<img width="1728" height="1039" alt="Screenshot 2025-07-18 at 2 37 32 PM" src="https://github.com/user-attachments/assets/49ae6f06-d4b9-4860-912e-c3c8dddeecfc" />



**Other test cases:**
| has layout | has sidebar | test | before | after |
| --- | --- | --- | --- | --- | 
| &#x274C; | &#x274C; | https://developer-stage.adobe.com/redocly-test/overflow/without-layout-without-sidebar | <img width="1728" height="1040" alt="b0l0s" src="https://github.com/user-attachments/assets/94198158-713c-494c-b8b5-3a7271be91c3" /> | <img width="1728" height="1042" alt="a0l0s" src="https://github.com/user-attachments/assets/53dbe581-e76d-4db3-b7c9-c6e0efc58c6e" /> | 
| &#x274C; | &#x2705; | https://developer-stage.adobe.com/redocly-test/overflow/without-layout-with-sidebar | <img width="1728" height="1040" alt="b0l1s" src="https://github.com/user-attachments/assets/f6113208-a379-414b-839c-5a8fab3abaf2" /> | <img width="1728" height="1042" alt="a0l1s" src="https://github.com/user-attachments/assets/cc51abbd-98a3-4a01-9d21-354155b03bd6" /> | 
| &#x2705; | &#x274C; | https://developer-stage.adobe.com/redocly-test/overflow/with-layout-without-sidebar| <img width="1728" height="1040" alt="b1l0s" src="https://github.com/user-attachments/assets/690d396c-53cf-404a-8558-b80bcb54260d" /> | <img width="1728" height="1041" alt="a1l0s" src="https://github.com/user-attachments/assets/d2248fa3-8eff-4502-93ef-d043a0fda817" /> | 
| &#x2705; | &#x2705; | https://developer-stage.adobe.com/redocly-test/overflow/with-layout-with-sidebar | <img width="1728" height="1040" alt="b1l1s" src="https://github.com/user-attachments/assets/541b97da-7192-40c5-a97a-f79c415ccd26" /> | <img width="1728" height="1040" alt="a1l1s" src="https://github.com/user-attachments/assets/9553c985-310a-4590-a35a-131bba9e44cb" /> | 










