### PR TITLE
feat: added the redocly loading spinner for the RedoclyAPIBlock (fixes #1638)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1204,7 +1204,7 @@ https://redocly.com/docs/api-reference-docs/configuration/functionality/#theme-o
 #### hideLoading (optional)
 
 ```js
-<RedoclyAPIBlock src="URL pointing to your open api yaml file." hideLoading={true} />
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." hideLoading />
 ```
 
 When set to `true` it disables the loading spinner when rendering an OpenAPI file client-side.

--- a/README.md
+++ b/README.md
@@ -1201,6 +1201,16 @@ Defaults to ```false```
 
 https://redocly.com/docs/api-reference-docs/configuration/functionality/#theme-object-openapi-schema
 
+#### hideLoading (optional)
+
+```js
+<RedoclyAPIBlock src="URL pointing to your open api yaml file." hideLoading={true} />
+```
+
+When set to `true` it disables the loading spinner when rendering an OpenAPI file client-side.
+
+Defaults to ```false```.
+
 #### hideTryItPanel (optional)
 
 ```js

--- a/example/gatsby-config.js
+++ b/example/gatsby-config.js
@@ -71,6 +71,11 @@ module.exports = {
             path: '/api/index.md/'
           },
           {
+            title: 'Analytics API - RedoclyAPIBlock',
+            description: 'This is the OpenAPI page of Adobe Analytics',
+            path: '/api-2.md/'
+          },
+          {
             title: 'Analytics Swagger file',
             description: 'External link',
             path: 'https://raw.githubusercontent.com/AdobeDocs/analytics-2.0-apis/master/docs/swagger.json'

--- a/example/src/pages/api-2.md
+++ b/example/src/pages/api-2.md
@@ -1,0 +1,5 @@
+---
+title: OpenAPI - Adobe Analytics
+layout: none
+--- 
+<RedoclyAPIBlock src="https://petstore3.swagger.io/api/v3/openapi.json" />

--- a/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
+++ b/packages/gatsby-theme-aio/src/components/RedoclyAPIBlock/index.js
@@ -26,6 +26,7 @@ const RedoclyAPIBlock = ({
   disableSidebar = false,
   disableSearch = false,
   ctrlFHijack = true,
+  hideLoading = false,
   hideTryItPanel = false,
   scrollYOffset = 0,
   sortOperationsAlphabetically = false,
@@ -79,7 +80,7 @@ const RedoclyAPIBlock = ({
                jsonSampleExpandLevel: ${jsonSampleExpandLevel === all ? `'${jsonSampleExpandLevel}'` : jsonSampleExpandLevel},
                ${generateCodeSamples ? "generateCodeSamples: { " + generateCodeSamples + "}," : ''}
                ${requestInterceptor ? "requestInterceptor: " + requestInterceptor + "," : ''}
-               hideLoading: true,
+               hideLoading: ${hideLoading},
                theme: {
                 ${typography ? "typography: { " + typography + "}," : ''}
                 rightPanel: {
@@ -104,6 +105,7 @@ RedoclyAPIBlock.propTypes = {
   codeBlock: PropTypes.string,
   disableSidebar: PropTypes.bool,
   disableSearch: PropTypes.bool,
+  hideLoading: PropTypes.bool,
   hideTryItPanel: PropTypes.bool,
   scrollYOffset: PropTypes.number,
   sortOperationsAlphabetically: PropTypes.bool,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

API playgrounds rendered with the `RedoclyAPIBlock` usually load on pages with `layout: none`, which means that for a short amount of time the page is empty, showing only the top navigation and the footer. When the request to retrieve an OpenAPI definition takes too long it might give the users the impression that the API playground doesn't work at all.

This PR sets the `hideLoading` configuration option [0] to its default of `false`, but allows overrides based on component properties.

[0] - https://redocly.com/docs-legacy/api-reference-docs/configuration/functionality

## Related Issue

https://github.com/adobe/aio-theme/issues/1638

## Motivation and Context

See the "Expected Behavior" from https://github.com/adobe/aio-theme/issues/1638.

## How Has This Been Tested?

* manually by calling the JS code that renders an API definition with the correct settings on an available playground`
* added an example page in the PR (cannot really be fully tested locally due to not serving the build via https, but the loading spinner is visible)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
